### PR TITLE
Add notification sound support for WSL/Windows

### DIFF
--- a/hooks/stop.sh
+++ b/hooks/stop.sh
@@ -315,7 +315,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
         osascript -e "display notification \"${_notif_names}\" with title \"🏆 ${COUNT} Achievements Unlocked!\" sound name \"Glass\""
     fi
 elif [[ -n "${WSL_DISTRO_NAME:-}" ]] || grep -qi microsoft /proc/version 2>/dev/null; then
-    # WSL: Windows toast notification via PowerShell
+    # WSL: Windows toast notification with sound via PowerShell
     # Build title and body strings
     if [[ "$COUNT" == "1" ]]; then
         _notif_title="🏆 Achievement Unlocked!"
@@ -334,7 +334,8 @@ elif [[ -n "${WSL_DISTRO_NAME:-}" ]] || grep -qi microsoft /proc/version 2>/dev/
 \$title = [System.Security.SecurityElement]::Escape('$_title_esc')
 \$body  = [System.Security.SecurityElement]::Escape('$_body_esc')
 \$xml   = New-Object Windows.Data.Xml.Dom.XmlDocument
-\$xml.LoadXml("<toast><visual><binding template='ToastGeneric'><text>\$title</text><text>\$body</text></binding></visual></toast>")
+# Add audio element for notification sound (ms-winsoundevent:Notification.Default)
+\$xml.LoadXml("<toast><visual><binding template='ToastGeneric'><text>\$title</text><text>\$body</text></binding></visual><audio src='ms-winsoundevent:Notification.Default'/></toast>")
 [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Claude Cheevos').Show([Windows.UI.Notifications.ToastNotification]::new(\$xml))
 PSEOF
     _win_ps_tmp=$(wslpath -w "$_ps_tmp")


### PR DESCRIPTION
## Summary
Adds audio feedback to achievement unlock notifications on WSL/Windows, bringing platform parity with macOS.

## Changes
- Modified `hooks/stop.sh` to include `<audio>` element in Toast XML
- Uses Windows default notification sound (`ms-winsoundevent:Notification.Default`)
- No new dependencies or external sound files required

## Before
WSL notifications were silent (visual only)

## After  
WSL notifications play Windows system sound when achievements unlock

## Testing
- ✅ Syntax validation passes (`bash -n hooks/stop.sh`)
- 🔲 Manual testing on WSL needed (maintainer to test)

## Platform Impact
- macOS: No changes
- WSL/Windows: Sound now plays
- Linux: No changes (no notification system)

## Related
Closes #19