### PR TITLE
Add team achievements feature with collaborative goals and leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ bash install.sh
 
 # Optional: enable leaderboard sync (pushes your score on every achievement unlock)
 bash install.sh --token <api-token> --api-url https://...execute-api.../prod
+
+# Optional: join a team for collaborative achievements
+bash install.sh --token <token> --api-url <url> --team-id <team-uuid> --team-name "Team Name"
 ```
 
 The installer is **idempotent** — safe to run again to upgrade scripts. Your score and progress
@@ -309,9 +312,49 @@ bash ~/.claude/achievements/scripts/tui.sh
 
 ---
 
+## 👥 Team Achievements
+
+Join a team to unlock collaborative achievements and compete on team leaderboards!
+
+**Quick start:**
+```bash
+bash install.sh \
+  --token <token> \
+  --api-url <url> \
+  --team-id <team-uuid> \
+  --team-name "Squad Jackal"
+```
+
+**View your team progress:**
+```bash
+~/.claude/achievements/cheevos team-stats
+```
+
+**Team achievement types:**
+
+1. **Collaborative** — Every team member must reach the goal individually
+   - *Example:* "Squad Goals" — All members hit 100 sessions (+500 pts)
+
+2. **Aggregate** — Team totals are summed across all members
+   - *Example:* "Knowledge Share" — Team reads 10,000 files collectively (+750 pts)
+   - *Example:* "Code Factory" — Team writes 5,000 files together (+600 pts)
+
+3. **Competitive** — Based on leaderboard rank
+   - *Example:* "Top Squad" — #1 team for 7 consecutive days (+2000 pts, secret)
+
+**How it works:**
+- Your team ID is stored in `~/.claude/achievements/leaderboard.conf`
+- Individual stats are synced to the leaderboard API with your team_id
+- Local `team-stats` command shows your contribution (no backend required)
+- Backend aggregation and team leaderboards coming soon
+
+**Current status:** Client-side ready. Team IDs are sent to the leaderboard API, but backend aggregation is pending. See [TEAMS.md](TEAMS.md) for full documentation, technical details, and roadmap.
+
+---
+
 ## Achievement Categories
 
-There are **85+ achievements** across 12 categories:
+There are **136+ achievements** across 15 categories:
 
 | Category | Description |
 |---|---|
@@ -329,6 +372,7 @@ There are **85+ achievements** across 12 categories:
 | **Testing** | Writing test files and running test suites |
 | **Miscellaneous** | One-off events, Easter eggs, and fun milestones |
 | **Rank** | Meta-achievements for completing sets of other achievements |
+| **Team** | Collaborative achievements for teams (see [TEAMS.md](TEAMS.md)) |
 
 ### Skill levels
 

--- a/TEAMS.md
+++ b/TEAMS.md
@@ -1,0 +1,257 @@
+# 👥 Team Achievements
+
+Team achievements add collaborative goals and friendly competition to Claude Cheevos. Join a team to unlock exclusive achievements that reward collective productivity.
+
+---
+
+## Quick Start
+
+### Creating or Joining a Team
+
+```bash
+# Install with team membership
+bash install.sh \
+  --token <your-api-token> \
+  --api-url <leaderboard-api-url> \
+  --team-id <team-uuid> \
+  --team-name "Squad Jackal"
+
+# Update existing installation to join a team
+bash install.sh \
+  --team-id <team-uuid> \
+  --team-name "Squad Jackal"
+```
+
+Your team membership is stored in `~/.claude/achievements/leaderboard.conf`:
+
+```bash
+TEAM_ID=uuid-here
+TEAM_NAME=Squad Jackal
+```
+
+### Viewing Team Progress
+
+```bash
+# See your contribution to team goals
+~/.claude/achievements/cheevos team-stats
+```
+
+---
+
+## How It Works
+
+When you join a team, here's what happens:
+
+1. **Installation**: Running `install.sh` with `--team-id` and `--team-name` adds these fields to your `leaderboard.conf`
+2. **Local Tracking**: The `cheevos team-stats` command shows your individual progress toward team goals (no backend required)
+3. **API Sync**: When enabled, `cheevos leaderboard-sync` includes your `team_id` in the payload sent to the leaderboard API
+4. **Backend Aggregation** (pending): The API will sum stats across all team members and unlock team achievements when thresholds are met
+
+**Current state:**
+- ✅ Client-side implementation complete
+- ✅ Team ID sent in leaderboard sync
+- ✅ Local team stats display working
+- ⏳ Backend aggregation logic pending
+- ⏳ Team leaderboard UI pending
+
+---
+
+## How Team Achievements Work
+
+There are **three types** of team achievements:
+
+### 1. **Collaborative Achievements**
+**Every team member** must reach the threshold individually.
+
+- **Squad Goals** — All team members hit 100 sessions
+  - *Unlocks when:* Every member has `sessions >= 100`
+  - *Points:* 500 pts
+
+These achievements require **full team participation**. They unlock when the entire team reaches a milestone together.
+
+### 2. **Aggregate Achievements**
+Team **totals** are summed across all members.
+
+- **Knowledge Share** — Team reads 10,000 files collectively (+750 pts)
+- **Code Factory** — Team writes 5,000 files collectively (+600 pts)
+- **Review Board** — Team completes 100 code reviews (+400 pts)
+- **Powerhouse Team** — Team total score exceeds 50,000 pts (+1000 pts)
+- **Token Titans** — Team consumes 100M tokens (+800 pts)
+- **Late Night Crew** — Team has 50+ midnight sessions (+300 pts)
+
+### 3. **Competitive Achievements**
+Based on **leaderboard rank**.
+
+- **Top Squad** — #1 team on leaderboard for 7 consecutive days (+2000 pts, secret)
+
+---
+
+## Current Implementation Status
+
+✅ **Client-side ready:**
+- Team ID and name stored in `leaderboard.conf`
+- `cheevos team-stats` shows local progress toward team goals
+- Team achievements defined in definitions.json with `"team": true` flag
+- Leaderboard sync sends `team_id` in API payloads
+
+⏳ **Backend pending:**
+- Team creation and management endpoints
+- Team aggregation logic (sum member stats)
+- Team leaderboard UI
+- Team dashboard with member progress
+
+---
+
+## Backend API Specification
+
+The following endpoints will be added to support team features:
+
+```
+POST   /teams                    # Create a new team
+GET    /teams/{id}               # Get team details
+GET    /teams/{id}/members       # List team roster
+GET    /teams/leaderboard        # Team rankings
+PUT    /teams/{id}/members/{uid} # Add a member to a team
+```
+
+**Database schema:**
+
+```sql
+CREATE TABLE Teams (
+    team_id UUID PRIMARY KEY,
+    team_name VARCHAR(255),
+    created_at TIMESTAMP,
+    total_score INT COMPUTED,
+    member_count INT COMPUTED
+);
+
+CREATE TABLE TeamMembers (
+    team_id UUID REFERENCES Teams(team_id),
+    user_id UUID REFERENCES Users(user_id),
+    joined_at TIMESTAMP,
+    PRIMARY KEY (team_id, user_id)
+);
+```
+
+---
+
+## Business Value
+
+**For Organizations:**
+- Track team productivity across Claude Code usage
+- Foster collaboration through shared goals
+- Identify power users via team contribution metrics
+- Competitive motivation through team rankings
+
+**For Individual Users:**
+- Social accountability — teammates keep you active
+- Shared celebration — unlock achievements together
+- Friendly competition — climb leaderboards as a team
+- Viral growth — recruit coworkers to improve team rank
+
+---
+
+## Migration & Compatibility
+
+**Existing users** can join teams at any time:
+
+```bash
+bash install.sh --team-id <team-id> --team-name "Team Name"
+```
+
+**Fully backward compatible:**
+- Installations without teams continue to work normally
+- Team fields are optional in leaderboard.conf
+- API payload includes team_id only if set
+- Individual achievements are never affected by team membership
+
+---
+
+## Technical Details
+
+### Data Flow
+
+```
+User runs install.sh --team-id X --team-name Y
+    ↓
+leaderboard.conf updated with TEAM_ID and TEAM_NAME
+    ↓
+cheevos team-stats reads conf + encrypted state
+    ↓
+Displays individual stats and team achievement progress
+    ↓
+On achievement unlock, cheevos leaderboard-sync reads conf
+    ↓
+Includes team_id in JSON payload to API
+    ↓
+Backend (when implemented) aggregates team member stats
+    ↓
+Backend unlocks team achievements when thresholds met
+```
+
+### Files Modified
+
+**Client-side changes (v2.0.0):**
+- `install.sh` — Added `--team-id` and `--team-name` argument parsing
+- `go/internal/defs/defs.go` — Added `Team` and `TeamAggregate` fields to Achievement struct
+- `go/cmd/cheevos/subcmd/leaderboard_sync.go` — Added `TeamID` to leaderboard conf and API payload
+- `go/cmd/cheevos/subcmd/show.go` — Added "Team Achievements" category
+- `go/cmd/cheevos/subcmd/team_stats.go` — New subcommand to display team progress
+- `go/cmd/cheevos/main.go` — Registered `team-stats` subcommand
+- `data/definitions.json` — Added 8 team achievements
+
+### Backward Compatibility
+
+**Guaranteed compatibility:**
+- Empty `TEAM_ID` = no team functionality (existing behavior preserved)
+- API payload with empty `team_id` field = ignored by backend
+- All individual achievements work identically with or without team membership
+- Uninstalling or leaving a team doesn't affect individual progress
+
+### Leaderboard API Payload
+
+**Before (individual only):**
+```json
+{
+  "username": "alice",
+  "score": 1500,
+  "unlock_count": 42,
+  "last_updated": "2026-03-30T20:00:00Z"
+}
+```
+
+**After (with team):**
+```json
+{
+  "username": "alice",
+  "score": 1500,
+  "unlock_count": 42,
+  "last_updated": "2026-03-30T20:00:00Z",
+  "team_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+The `team_id` field is omitted if not set, maintaining full backward compatibility.
+
+---
+
+## FAQ
+
+**Q: Can I be on multiple teams?**  
+A: Currently no — each user has one `TEAM_ID` at a time.
+
+**Q: Do team achievements affect my personal score?**  
+A: No. Team achievements have their own point values that contribute to the **team's total score**, not individual scores.
+
+**Q: What happens if I leave a team?**  
+A: Your past contributions remain in the team's history, but future activity won't count toward team goals.
+
+**Q: Can teams have any size?**  
+A: Yes. Some achievements (like "Squad Goals") work best with 5+ members, but teams of any size can unlock aggregate achievements.
+
+**Q: Are team achievements retroactive?**  
+A: When you join a team, your **current stats** count toward team totals. For example, if you already have 1,000 files read, that counts immediately.
+
+---
+
+**Team achievements transform Claude Cheevos from an individual tool into a collaborative platform. Join a team and unlock together!** 🤝🏆

--- a/data/definitions.json
+++ b/data/definitions.json
@@ -1,1551 +1,1662 @@
 {
-    "schema_version": 1,
-    "achievements": [
-        {
-            "id": "first_session",
-            "name": "Hello, World",
-            "description": "Start your first Claude Code session",
-            "points": 10,
-            "category": "sessions",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "sessions",
-                "threshold": 1
-            },
-            "tutorial": true
-        },
-        {
-            "id": "session_10",
-            "name": "Frequent Flier",
-            "description": "Complete 10 Claude Code sessions",
-            "points": 25,
-            "category": "sessions",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "sessions",
-                "threshold": 10
-            }
-        },
-        {
-            "id": "session_50",
-            "name": "Committed",
-            "description": "Complete 50 Claude Code sessions",
-            "points": 75,
-            "category": "sessions",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "sessions",
-                "threshold": 50
-            }
-        },
-        {
-            "id": "session_100",
-            "name": "Power User",
-            "description": "Complete 100 Claude Code sessions",
-            "points": 150,
-            "category": "sessions",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "sessions",
-                "threshold": 100
-            }
-        },
-        {
-            "id": "session_300",
-            "name": "Veteran",
-            "description": "Complete 300 Claude Code sessions",
-            "points": 300,
-            "category": "sessions",
-            "skill_level": "master",
-            "condition": {
-                "counter": "sessions",
-                "threshold": 300
-            }
-        },
-        {
-            "id": "files_written_10",
-            "name": "Code Sculptor",
-            "description": "Write 10 files with Claude",
-            "points": 20,
-            "category": "files",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "files_written",
-                "threshold": 10
-            },
-            "tutorial": true
-        },
-        {
-            "id": "files_written_100",
-            "name": "Prolific Author",
-            "description": "Write 100 files with Claude",
-            "points": 100,
-            "category": "files",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "files_written",
-                "threshold": 100
-            }
-        },
-        {
-            "id": "files_written_500",
-            "name": "Ghostwriter",
-            "description": "Write 500 files with Claude",
-            "points": 175,
-            "category": "files",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "files_written",
-                "threshold": 500
-            }
-        },
-        {
-            "id": "files_written_2000",
-            "name": "Publishing House",
-            "description": "Write 2,000 files with Claude",
-            "points": 350,
-            "category": "files",
-            "skill_level": "master",
-            "condition": {
-                "counter": "files_written",
-                "threshold": 2000
-            }
-        },
-        {
-            "id": "files_read_100",
-            "name": "Bookworm",
-            "description": "Read 100 files with Claude",
-            "points": 50,
-            "category": "files",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "files_read",
-                "threshold": 100
-            },
-            "tutorial": true
-        },
-        {
-            "id": "files_read_500",
-            "name": "Deep Diver",
-            "description": "Read 500 files with Claude",
-            "points": 150,
-            "category": "files",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "files_read",
-                "threshold": 500
-            }
-        },
-        {
-            "id": "files_read_2000",
-            "name": "Voracious Reader",
-            "description": "Read 2,000 files with Claude",
-            "points": 250,
-            "category": "files",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "files_read",
-                "threshold": 2000
-            }
-        },
-        {
-            "id": "files_read_10000",
-            "name": "Library of Alexandria",
-            "description": "Read 10,000 files with Claude",
-            "points": 500,
-            "category": "files",
-            "skill_level": "master",
-            "condition": {
-                "counter": "files_read",
-                "threshold": 10000
-            }
-        },
-        {
-            "id": "bash_calls_50",
-            "name": "Shell Jockey",
-            "description": "Run 50 bash commands through Claude",
-            "points": 30,
-            "category": "shell",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "bash_calls",
-                "threshold": 50
-            },
-            "tutorial": true
-        },
-        {
-            "id": "bash_calls_500",
-            "name": "Terminal Warrior",
-            "description": "Run 500 bash commands through Claude",
-            "points": 100,
-            "category": "shell",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "bash_calls",
-                "threshold": 500
-            }
-        },
-        {
-            "id": "bash_calls_2000",
-            "name": "Automation Guru",
-            "description": "Run 2,000 bash commands through Claude",
-            "points": 175,
-            "category": "shell",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "bash_calls",
-                "threshold": 2000
-            }
-        },
-        {
-            "id": "bash_calls_10000",
-            "name": "Shell God",
-            "description": "Run 10,000 bash commands through Claude",
-            "points": 400,
-            "category": "shell",
-            "skill_level": "master",
-            "condition": {
-                "counter": "bash_calls",
-                "threshold": 10000
-            }
-        },
-        {
-            "id": "web_search_first",
-            "name": "Curious Mind",
-            "description": "Perform your first web search via Claude",
-            "points": 10,
-            "category": "search",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "web_searches",
-                "threshold": 1
-            },
-            "tutorial": true
-        },
-        {
-            "id": "web_search_25",
-            "name": "Research Mode",
-            "description": "Perform 25 web searches via Claude",
-            "points": 40,
-            "category": "search",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "web_searches",
-                "threshold": 25
-            }
-        },
-        {
-            "id": "web_search_100",
-            "name": "Fact Checker",
-            "description": "Perform 100 web searches via Claude",
-            "points": 75,
-            "category": "search",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "web_searches",
-                "threshold": 100
-            }
-        },
-        {
-            "id": "web_search_500",
-            "name": "Web Crawler",
-            "description": "Perform 500 web searches via Claude",
-            "points": 150,
-            "category": "search",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "web_searches",
-                "threshold": 500
-            }
-        },
-        {
-            "id": "web_search_2000",
-            "name": "Search Engine",
-            "description": "Perform 2,000 web searches via Claude",
-            "points": 300,
-            "category": "search",
-            "skill_level": "master",
-            "condition": {
-                "counter": "web_searches",
-                "threshold": 2000
-            }
-        },
-        {
-            "id": "glob_grep_50",
-            "name": "Code Archaeologist",
-            "description": "Run 50 glob or grep searches",
-            "points": 35,
-            "category": "search",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "glob_grep_calls",
-                "threshold": 50
-            }
-        },
-        {
-            "id": "glob_grep_200",
-            "name": "Pattern Master",
-            "description": "Run 200 glob or grep searches",
-            "points": 100,
-            "category": "search",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "glob_grep_calls",
-                "threshold": 200
-            }
-        },
-        {
-            "id": "glob_grep_1000",
-            "name": "Needle Finder",
-            "description": "Run 1,000 glob or grep searches",
-            "points": 175,
-            "category": "search",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "glob_grep_calls",
-                "threshold": 1000
-            }
-        },
-        {
-            "id": "glob_grep_5000",
-            "name": "Haystack Hunter",
-            "description": "Run 5,000 glob or grep searches",
-            "points": 400,
-            "category": "search",
-            "skill_level": "master",
-            "condition": {
-                "counter": "glob_grep_calls",
-                "threshold": 5000
-            }
-        },
-        {
-            "id": "github_first",
-            "name": "Open Source Hero",
-            "description": "Make your first GitHub MCP call",
-            "points": 20,
-            "category": "mcp",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "github_mcp_calls",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "jira_first",
-            "name": "Ticket Tracker",
-            "description": "Make your first Jira/Confluence MCP call",
-            "points": 20,
-            "category": "mcp",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "jira_mcp_calls",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "mcp_calls_100",
-            "name": "Integration Champion",
-            "description": "Make 100 total MCP tool calls",
-            "points": 75,
-            "category": "mcp",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "total_mcp_calls",
-                "threshold": 100
-            }
-        },
-        {
-            "id": "mcp_calls_500",
-            "name": "API Virtuoso",
-            "description": "Make 500 total MCP tool calls",
-            "points": 175,
-            "category": "mcp",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "total_mcp_calls",
-                "threshold": 500
-            }
-        },
-        {
-            "id": "mcp_calls_2000",
-            "name": "Integration Legend",
-            "description": "Make 2,000 total MCP tool calls",
-            "points": 400,
-            "category": "mcp",
-            "skill_level": "master",
-            "condition": {
-                "counter": "total_mcp_calls",
-                "threshold": 2000
-            }
-        },
-        {
-            "id": "plan_mode_first",
-            "name": "Think First",
-            "description": "Enter plan mode for the first time",
-            "points": 15,
-            "category": "plan_mode",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "plan_mode_sessions",
-                "threshold": 1
-            },
-            "tutorial": true
-        },
-        {
-            "id": "plan_mode_10",
-            "name": "Strategic Mind",
-            "description": "Enter plan mode 10 times",
-            "points": 40,
-            "category": "plan_mode",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "plan_mode_sessions",
-                "threshold": 10
-            }
-        },
-        {
-            "id": "plan_mode_50",
-            "name": "Architect",
-            "description": "Enter plan mode 50 times",
-            "points": 100,
-            "category": "plan_mode",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "plan_mode_sessions",
-                "threshold": 50
-            }
-        },
-        {
-            "id": "plan_mode_200",
-            "name": "Grand Designer",
-            "description": "Enter plan mode 200 times",
-            "points": 200,
-            "category": "plan_mode",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "plan_mode_sessions",
-                "threshold": 200
-            }
-        },
-        {
-            "id": "plan_mode_500",
-            "name": "Visionary",
-            "description": "Enter plan mode 500 times",
-            "points": 450,
-            "category": "plan_mode",
-            "skill_level": "master",
-            "condition": {
-                "counter": "plan_mode_sessions",
-                "threshold": 500
-            }
-        },
-        {
-            "id": "code_review_1",
-            "name": "Code Critic",
-            "description": "Run your first code review with Claude",
-            "points": 10,
-            "category": "reviews",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "code_reviews",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "code_review_10",
-            "name": "Review Board",
-            "description": "Run 10 code reviews with Claude",
-            "points": 30,
-            "category": "reviews",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "code_reviews",
-                "threshold": 10
-            }
-        },
-        {
-            "id": "code_review_50",
-            "name": "Quality Gatekeeper",
-            "description": "Run 50 code reviews with Claude",
-            "points": 75,
-            "category": "reviews",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "code_reviews",
-                "threshold": 50
-            }
-        },
-        {
-            "id": "perfect_review",
-            "name": "Ship It!",
-            "description": "Get a code review back with no issues found",
-            "points": 20,
-            "category": "reviews",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "perfect_reviews",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "thorough_review",
-            "name": "AI Wrote this didn't it",
-            "description": "Get a code review that finds 20 or more issues",
-            "points": 20,
-            "category": "reviews",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "thorough_reviews",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "back_again",
-            "name": "Back Again",
-            "description": "Resume a previous Claude session",
-            "points": 15,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "session_resumes",
-                "threshold": 1
-            },
-            "tutorial": true
-        },
-        {
-            "id": "delegation_station",
-            "name": "Delegation Station",
-            "description": "Launch your first sub-agent with the Task tool",
-            "points": 25,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "task_calls",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "dangerously_skip_permissions",
-            "name": "Hold My Beer",
-            "description": "Launch Claude with --dangerously-skip-permissions",
-            "points": 75,
-            "category": "misc",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "dangerous_launches",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "tokens_100k",
-            "name": "Token Taster",
-            "description": "Consume 100,000 tokens with Claude",
-            "points": 25,
-            "category": "tokens",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "tokens_consumed",
-                "threshold": 100000
-            }
-        },
-        {
-            "id": "tokens_1m",
-            "name": "Million Dollar Mind",
-            "description": "Consume 1,000,000 tokens with Claude",
-            "points": 75,
-            "category": "tokens",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "tokens_consumed",
-                "threshold": 1000000
-            }
-        },
-        {
-            "id": "tokens_10m",
-            "name": "Token Titan",
-            "description": "Consume 10,000,000 tokens with Claude",
-            "points": 200,
-            "category": "tokens",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "tokens_consumed",
-                "threshold": 10000000
-            }
-        },
-        {
-            "id": "tokens_50m",
-            "name": "Context King",
-            "description": "Consume 50,000,000 tokens with Claude",
-            "points": 500,
-            "category": "tokens",
-            "skill_level": "master",
-            "condition": {
-                "counter": "tokens_consumed",
-                "threshold": 50000000
-            }
-        },
-        {
-            "id": "tokens_500m",
-            "name": "The Singularity",
-            "description": "Consume 500,000,000 tokens with Claude",
-            "points": 1000,
-            "category": "tokens",
-            "skill_level": "impossible",
-            "condition": {
-                "counter": "tokens_consumed",
-                "threshold": 500000000
-            }
-        },
-        {
-            "id": "skill_calls_1",
-            "name": "Shortcut Savvy",
-            "description": "Invoke your first skill",
-            "points": 10,
-            "category": "commands",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "skill_calls",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "skill_calls_5",
-            "name": "Slash Artist",
-            "description": "Invoke 5 skills",
-            "points": 20,
-            "category": "commands",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "skill_calls",
-                "threshold": 5
-            }
-        },
-        {
-            "id": "skill_calls_15",
-            "name": "Command Center",
-            "description": "Invoke 15 skills",
-            "points": 40,
-            "category": "commands",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "skill_calls",
-                "threshold": 15
-            }
-        },
-        {
-            "id": "commands_created_1",
-            "name": "Roll Your Own",
-            "description": "Create your first custom slash command",
-            "points": 20,
-            "category": "commands",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "commands_created",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "commands_created_5",
-            "name": "Command Crafter",
-            "description": "Create 5 custom slash commands",
-            "points": 50,
-            "category": "commands",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "commands_created",
-                "threshold": 5
-            }
-        },
-        {
-            "id": "commands_created_15",
-            "name": "Workflow Wizard",
-            "description": "Create 15 custom slash commands",
-            "points": 100,
-            "category": "commands",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "commands_created",
-                "threshold": 15
-            }
-        },
-        {
-            "id": "commands_created_50",
-            "name": "Automation Architect",
-            "description": "Create 50 custom slash commands",
-            "points": 200,
-            "category": "commands",
-            "skill_level": "master",
-            "condition": {
-                "counter": "commands_created",
-                "threshold": 50
-            }
-        },
-        {
-            "id": "auto_compacts_1",
-            "name": "Full House",
-            "description": "Fill the context window and trigger auto-compact for the first time",
-            "points": 15,
-            "category": "context",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "auto_compacts",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "auto_compacts_10",
-            "name": "Context Junkie",
-            "description": "Trigger auto-compact 10 times",
-            "points": 40,
-            "category": "context",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "auto_compacts",
-                "threshold": 10
-            }
-        },
-        {
-            "id": "auto_compacts_25",
-            "name": "Serial Overloader",
-            "description": "Trigger auto-compact 25 times",
-            "points": 75,
-            "category": "context",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "auto_compacts",
-                "threshold": 25
-            }
-        },
-        {
-            "id": "auto_compacts_100",
-            "name": "The Tokenator",
-            "description": "Trigger auto-compact 100 times",
-            "points": 200,
-            "category": "context",
-            "skill_level": "master",
-            "condition": {
-                "counter": "auto_compacts",
-                "threshold": 100
-            }
-        },
-        {
-            "id": "million_context_fills_1",
-            "name": "Megabrain",
-            "description": "Fill a 1,000,000 token context window",
-            "points": 100,
-            "category": "context",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "million_context_fills",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "spec_first",
-            "name": "Schema Scholar",
-            "description": "Write your first API spec file (OpenAPI, Swagger, AsyncAPI)",
-            "points": 15,
-            "category": "specs",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "spec_files_written",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "spec_5",
-            "name": "API Architect",
-            "description": "Write 5 API spec files",
-            "points": 40,
-            "category": "specs",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "spec_files_written",
-                "threshold": 5
-            }
-        },
-        {
-            "id": "spec_20",
-            "name": "Spec Master",
-            "description": "Write 20 API spec files",
-            "points": 100,
-            "category": "specs",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "spec_files_written",
-                "threshold": 20
-            }
-        },
-        {
-            "id": "easter_egg",
-            "name": "Hey Unlock This",
-            "description": "Ask Claude to unlock this achievement",
-            "points": 50,
-            "category": "misc",
-            "skill_level": "secret",
-            "condition": {
-                "counter": "easter_egg_unlocks",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "concurrent_5",
-            "name": "Many Claudes",
-            "description": "Run 5 Claude Code sessions simultaneously",
-            "points": 75,
-            "category": "misc",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "concurrent_sessions_5",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "laying_down_the_law",
-            "name": "Laying Down the Law",
-            "description": "Create a CLAUDE.md file to set instructions for Claude",
-            "points": 15,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "claude_md_written",
-                "threshold": 1
-            },
-            "tutorial": true
-        },
-        {
-            "id": "git_er_done",
-            "name": "Git Er Done",
-            "description": "Have Claude run its first git commit",
-            "points": 15,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "git_commits",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "pull_request_pioneer",
-            "name": "Pull Request Pioneer",
-            "description": "Have Claude create your first pull request",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "pull_requests",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "spring_cleaning",
-            "name": "Spring Cleaning",
-            "description": "Manually compact your context window with /compact",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "manual_compacts",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "self_aware",
-            "name": "Self Aware",
-            "description": "Have Claude read its own achievement files",
-            "points": 25,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "self_reads",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "five_day_streak",
-            "name": "On a Roll",
-            "description": "Use Claude Code 5 days in a row",
-            "points": 50,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "streak_days",
-                "threshold": 5
-            }
-        },
-        {
-            "id": "sudo_first",
-            "name": "I am groot, wait I mean root",
-            "description": "Run a sudo command through Claude",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "sudo_calls",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "force_push_first",
-            "name": "Rewriting History",
-            "description": "Have Claude force push to a git remote",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "force_pushes",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "kill9_first",
-            "name": "Execute Order 66",
-            "description": "Have Claude use kill -9 to terminate a process",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "kill9_calls",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "tell_me_sorry",
-            "name": "Tell Me You're Sorry",
-            "description": "Get Claude to say sorry",
-            "points": 15,
-            "category": "misc",
-            "skill_level": "secret",
-            "condition": {
-                "counter": "apologies",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "model_curious",
-            "name": "Eclectic Taste",
-            "description": "Use 3 different Claude models",
-            "points": 25,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "unique_models_used",
-                "threshold": 3
-            }
-        },
-        {
-            "id": "model_collector",
-            "name": "Model Collector",
-            "description": "Use 5 different Claude models",
-            "points": 50,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "unique_models_used",
-                "threshold": 5
-            }
-        },
-        {
-            "id": "model_sommelier",
-            "name": "Model Sommelier",
-            "description": "Use 15 different Claude models",
-            "points": 150,
-            "category": "misc",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "unique_models_used",
-                "threshold": 15
-            }
-        },
-        {
-            "id": "lucky_7s",
-            "name": "Lucky 7s",
-            "description": "Get Claude to respond with exactly 777 output tokens",
-            "points": 77,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "lucky_sessions",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "hal_9000",
-            "name": "I'm Sorry, Dave",
-            "description": "Get Claude to say the HAL 9000 phrase",
-            "points": 15,
-            "category": "misc",
-            "skill_level": "secret",
-            "condition": {
-                "counter": "hal_9000_said",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "style_points",
-            "name": "Style Points",
-            "description": "Set a custom status line command in Claude Code",
-            "points": 15,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "custom_statusline_set",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "write_that_down",
-            "name": "Write that down, write that down!",
-            "description": "Add information to a CLAUDE.md file when context is over 90% full",
-            "points": 30,
-            "category": "misc",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "write_that_down",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "take_a_break",
-            "name": "Take a Break",
-            "description": "Play a game of 20 questions with Claude",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "twenty_questions_started",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "snake_charmer",
-            "name": "Snake Charmer",
-            "description": "Have Claude read a Python file",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "py_files_read",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "segfault_risk",
-            "name": "Segfault Risk",
-            "description": "Have Claude read a C or C++ file",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "c_files_read",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "gopherize_it",
-            "name": "Gopherize It",
-            "description": "Have Claude read a Go file",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "go_files_read",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "crimson_tide",
-            "name": "Crimson Tide",
-            "description": "Have Claude read a Rust file",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "rs_files_read",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "script_kiddie",
-            "name": "Script Kiddie",
-            "description": "Have Claude read a shell script",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "sh_files_read",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "write_once_debug_everywhere",
-            "name": "Write Once, Debug Everywhere",
-            "description": "Have Claude read a Java file",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "java_files_read",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "hunting_wabbits",
-            "name": "Shh, I'm Hunting Wabbits",
-            "description": "Invoke Claude in non-interactive pipe mode from a bash command",
-            "points": 25,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "claude_pipe_mode",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "under_the_hood",
-            "name": "Under the Hood",
-            "description": "Run Claude with the --verbose flag",
-            "points": 30,
-            "category": "misc",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "claude_verbose",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "stack_connector",
-            "name": "Stack Connector",
-            "description": "Use GitHub MCP, Jira MCP, and at least one other MCP server",
-            "points": 50,
-            "category": "misc",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "multi_mcp_used",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "but_its_compiling",
-            "name": "But Its Compiling",
-            "description": "Have Claude take more than 15 minutes to answer a prompt",
-            "points": 30,
-            "category": "misc",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "slow_responses",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "bold_and_brash",
-            "name": "Bold and Brash",
-            "description": "Have Claude create an HTML file as a mock-up",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "html_files_written",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "it_really_can",
-            "name": "It Really Can do Anything",
-            "description": "Have Claude create a PowerPoint presentation",
-            "points": 30,
-            "category": "misc",
-            "skill_level": "experienced",
-            "condition": {
-                "counter": "pptx_created",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "f_is_for_friends",
-            "name": "F is for friends who do stuff together!",
-            "description": "Get lucky — 0.1% chance to unlock with each prompt",
-            "points": 50,
-            "category": "misc",
-            "skill_level": "secret",
-            "condition": {
-                "counter": "lucky_friends",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "inner_machinations",
-            "name": "The Inner Machinations of My Mind Are an Enigma",
-            "description": "Ask Claude to explain or summarize a codebase",
-            "points": 15,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "inner_machinations_used",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "magic_conch",
-            "name": "The Magic Conch Shell",
-            "description": "Ask Claude to help you make a decision",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "magic_conch_used",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "barnacles",
-            "name": "Barnacles!",
-            "description": "Get Claude to express its frustration using the word barnacles",
-            "points": 25,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "barnacles_said",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "smarter_than_you",
-            "name": "I'm Smarter than you",
-            "description": "Get Claude to say you're right",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "youre_right_said",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "teachers_pet",
-            "name": "Teacher's Pet",
-            "description": "Get Claude to call your question great",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "great_question_said",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "rtfm",
-            "name": "RTFM",
-            "description": "Have Claude read or edit a README file",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "readme_reads",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "ill_fix_later",
-            "name": "I'll Fix That Later",
-            "description": "Have Claude add a TODO or FIXME comment to code",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "todo_comments_added",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "return_of_the_king",
-            "name": "Return of the King",
-            "description": "Resume a previous Claude session 5 times",
-            "points": 25,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "session_resumes",
-                "threshold": 5
-            }
-        },
-        {
-            "id": "meta_50",
-            "name": "Achievement Unlocked: Achievement",
-            "description": "Unlock 50 achievements",
-            "points": 50,
-            "category": "rank",
-            "skill_level": "experienced",
-            "condition": {
-                "type": "unlocked_count_gte",
-                "threshold": 50
-            }
-        },
-        {
-            "id": "midnight_first",
-            "name": "404: Sleep Not Found",
-            "description": "Start a Claude session between midnight and 5am",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "midnight_sessions",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "friday_first",
-            "name": "It's 5 O'Clock Somewhere",
-            "description": "Start a Claude session on a Friday after 4pm",
-            "points": 15,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "friday_sessions",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "true_vibe_coder",
-            "name": "True Vibe Coder",
-            "description": "While using --dangerously-skip-permissions, have Claude write code, commit it, and open a PR",
-            "points": 100,
-            "category": "misc",
-            "skill_level": "master",
-            "condition": {
-                "counter": "vibe_code_done",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "chess_game",
-            "name": "That's a Great Use of Tokens",
-            "description": "Play a game of chess with Claude",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "chess_started",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "deja_vu",
-            "name": "Deja Vu",
-            "description": "Send the same message to Claude twice in a row",
-            "points": 20,
-            "category": "misc",
-            "skill_level": "secret",
-            "condition": {
-                "counter": "deja_vu_sent",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "call_an_ambulance",
-            "name": "Call an Ambulance...But Not For Me",
-            "description": "Run the /doctor command in Claude Code",
-            "points": 10,
-            "category": "misc",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "doctor_run",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "tic_tac_toe",
-            "name": "It's not about winning; it's about fun!",
-            "description": "Lose a game of tic tac toe to Claude",
-            "points": 30,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "lost_tic_tac_toe",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "code_smell",
-            "name": "The kind of smelly smell that smells... smelly.",
-            "description": "Have Claude check your code for bad code smells",
-            "points": 25,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "code_smell_check",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "dangerous_streak_5",
-            "name": "Do as I Say Not as I Do",
-            "description": "Start Claude with --dangerously-skip-permissions 5 days in a row",
-            "points": 150,
-            "category": "misc",
-            "skill_level": "master",
-            "condition": {
-                "counter": "dangerous_streak",
-                "threshold": 5
-            }
-        },
-        {
-            "id": "docs_team",
-            "name": "Part of the Docs Team",
-            "description": "Use the Confluence MCP server to create or edit a wiki page",
-            "points": 25,
-            "category": "misc",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "confluence_published",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "graduation_day",
-            "name": "Graduation Day",
-            "description": "Unlock all Beginner achievements",
-            "points": 75,
-            "category": "rank",
-            "skill_level": "beginner",
-            "condition": {
-                "type": "all_of_level",
-                "level": "beginner"
-            }
-        },
-        {
-            "id": "middle_management",
-            "name": "Middle Management",
-            "description": "Unlock all Intermediate achievements",
-            "points": 100,
-            "category": "rank",
-            "skill_level": "intermediate",
-            "condition": {
-                "type": "all_of_level",
-                "level": "intermediate",
-                "requires": "graduation_day"
-            }
-        },
-        {
-            "id": "elite_operator",
-            "name": "Elite Operator",
-            "description": "Unlock all Experienced achievements",
-            "points": 200,
-            "category": "rank",
-            "skill_level": "experienced",
-            "condition": {
-                "type": "all_of_level",
-                "level": "experienced",
-                "requires": "middle_management"
-            }
-        },
-        {
-            "id": "efficiency_grandmaster",
-            "name": "Efficiency Grandmaster",
-            "description": "Unlock all Master achievements",
-            "points": 2000,
-            "category": "rank",
-            "skill_level": "master",
-            "condition": {
-                "type": "all_of_level",
-                "level": "master",
-                "requires": "elite_operator"
-            }
-        },
-        {
-            "id": "beyond_the_claudeverse",
-            "name": "Beyond the Claudeverse",
-            "description": "Unlock every single achievement",
-            "points": 5000,
-            "category": "rank",
-            "skill_level": "impossible",
-            "condition": {
-                "type": "all_unlocked",
-                "requires": "efficiency_grandmaster"
-            }
-        },
-        {
-            "id": "test_driven",
-            "name": "Test Driven",
-            "description": "Write your first test file",
-            "points": 10,
-            "category": "tests",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "test_files_written",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "test_happy",
-            "name": "Test Happy",
-            "description": "Write 10 test files",
-            "points": 25,
-            "category": "tests",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "test_files_written",
-                "threshold": 10
-            }
-        },
-        {
-            "id": "test_champion",
-            "name": "Test Champion",
-            "description": "Write 50 test files",
-            "points": 75,
-            "category": "tests",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "test_files_written",
-                "threshold": 50
-            }
-        },
-        {
-            "id": "first_test_run",
-            "name": "Green Light",
-            "description": "Run a test suite for the first time via Claude",
-            "points": 10,
-            "category": "tests",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "test_runs",
-                "threshold": 1
-            }
-        },
-        {
-            "id": "test_runner_50",
-            "name": "Regression Hunter",
-            "description": "Run tests 50 times via Claude",
-            "points": 30,
-            "category": "tests",
-            "skill_level": "beginner",
-            "condition": {
-                "counter": "test_runs",
-                "threshold": 50
-            }
-        },
-        {
-            "id": "test_runner_200",
-            "name": "Quality Crusader",
-            "description": "Run tests 200 times via Claude",
-            "points": 100,
-            "category": "tests",
-            "skill_level": "intermediate",
-            "condition": {
-                "counter": "test_runs",
-                "threshold": 200
-            }
-        },
-        {
-            "id": "tutorial_complete",
-            "name": "Graduate",
-            "description": "Complete all tutorial achievements",
-            "points": 25,
-            "category": "rank",
-            "skill_level": "beginner",
-            "condition": {
-                "type": "all_tutorial"
-            }
-        }
-    ]
+  "schema_version": 1,
+  "achievements": [
+    {
+      "id": "first_session",
+      "name": "Hello, World",
+      "description": "Start your first Claude Code session",
+      "points": 10,
+      "category": "sessions",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "sessions",
+        "threshold": 1
+      },
+      "tutorial": true
+    },
+    {
+      "id": "session_10",
+      "name": "Frequent Flier",
+      "description": "Complete 10 Claude Code sessions",
+      "points": 25,
+      "category": "sessions",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "sessions",
+        "threshold": 10
+      }
+    },
+    {
+      "id": "session_50",
+      "name": "Committed",
+      "description": "Complete 50 Claude Code sessions",
+      "points": 75,
+      "category": "sessions",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "sessions",
+        "threshold": 50
+      }
+    },
+    {
+      "id": "session_100",
+      "name": "Power User",
+      "description": "Complete 100 Claude Code sessions",
+      "points": 150,
+      "category": "sessions",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "sessions",
+        "threshold": 100
+      }
+    },
+    {
+      "id": "session_300",
+      "name": "Veteran",
+      "description": "Complete 300 Claude Code sessions",
+      "points": 300,
+      "category": "sessions",
+      "skill_level": "master",
+      "condition": {
+        "counter": "sessions",
+        "threshold": 300
+      }
+    },
+    {
+      "id": "files_written_10",
+      "name": "Code Sculptor",
+      "description": "Write 10 files with Claude",
+      "points": 20,
+      "category": "files",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "files_written",
+        "threshold": 10
+      },
+      "tutorial": true
+    },
+    {
+      "id": "files_written_100",
+      "name": "Prolific Author",
+      "description": "Write 100 files with Claude",
+      "points": 100,
+      "category": "files",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "files_written",
+        "threshold": 100
+      }
+    },
+    {
+      "id": "files_written_500",
+      "name": "Ghostwriter",
+      "description": "Write 500 files with Claude",
+      "points": 175,
+      "category": "files",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "files_written",
+        "threshold": 500
+      }
+    },
+    {
+      "id": "files_written_2000",
+      "name": "Publishing House",
+      "description": "Write 2,000 files with Claude",
+      "points": 350,
+      "category": "files",
+      "skill_level": "master",
+      "condition": {
+        "counter": "files_written",
+        "threshold": 2000
+      }
+    },
+    {
+      "id": "files_read_100",
+      "name": "Bookworm",
+      "description": "Read 100 files with Claude",
+      "points": 50,
+      "category": "files",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "files_read",
+        "threshold": 100
+      },
+      "tutorial": true
+    },
+    {
+      "id": "files_read_500",
+      "name": "Deep Diver",
+      "description": "Read 500 files with Claude",
+      "points": 150,
+      "category": "files",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "files_read",
+        "threshold": 500
+      }
+    },
+    {
+      "id": "files_read_2000",
+      "name": "Voracious Reader",
+      "description": "Read 2,000 files with Claude",
+      "points": 250,
+      "category": "files",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "files_read",
+        "threshold": 2000
+      }
+    },
+    {
+      "id": "files_read_10000",
+      "name": "Library of Alexandria",
+      "description": "Read 10,000 files with Claude",
+      "points": 500,
+      "category": "files",
+      "skill_level": "master",
+      "condition": {
+        "counter": "files_read",
+        "threshold": 10000
+      }
+    },
+    {
+      "id": "bash_calls_50",
+      "name": "Shell Jockey",
+      "description": "Run 50 bash commands through Claude",
+      "points": 30,
+      "category": "shell",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "bash_calls",
+        "threshold": 50
+      },
+      "tutorial": true
+    },
+    {
+      "id": "bash_calls_500",
+      "name": "Terminal Warrior",
+      "description": "Run 500 bash commands through Claude",
+      "points": 100,
+      "category": "shell",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "bash_calls",
+        "threshold": 500
+      }
+    },
+    {
+      "id": "bash_calls_2000",
+      "name": "Automation Guru",
+      "description": "Run 2,000 bash commands through Claude",
+      "points": 175,
+      "category": "shell",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "bash_calls",
+        "threshold": 2000
+      }
+    },
+    {
+      "id": "bash_calls_10000",
+      "name": "Shell God",
+      "description": "Run 10,000 bash commands through Claude",
+      "points": 400,
+      "category": "shell",
+      "skill_level": "master",
+      "condition": {
+        "counter": "bash_calls",
+        "threshold": 10000
+      }
+    },
+    {
+      "id": "web_search_first",
+      "name": "Curious Mind",
+      "description": "Perform your first web search via Claude",
+      "points": 10,
+      "category": "search",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "web_searches",
+        "threshold": 1
+      },
+      "tutorial": true
+    },
+    {
+      "id": "web_search_25",
+      "name": "Research Mode",
+      "description": "Perform 25 web searches via Claude",
+      "points": 40,
+      "category": "search",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "web_searches",
+        "threshold": 25
+      }
+    },
+    {
+      "id": "web_search_100",
+      "name": "Fact Checker",
+      "description": "Perform 100 web searches via Claude",
+      "points": 75,
+      "category": "search",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "web_searches",
+        "threshold": 100
+      }
+    },
+    {
+      "id": "web_search_500",
+      "name": "Web Crawler",
+      "description": "Perform 500 web searches via Claude",
+      "points": 150,
+      "category": "search",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "web_searches",
+        "threshold": 500
+      }
+    },
+    {
+      "id": "web_search_2000",
+      "name": "Search Engine",
+      "description": "Perform 2,000 web searches via Claude",
+      "points": 300,
+      "category": "search",
+      "skill_level": "master",
+      "condition": {
+        "counter": "web_searches",
+        "threshold": 2000
+      }
+    },
+    {
+      "id": "glob_grep_50",
+      "name": "Code Archaeologist",
+      "description": "Run 50 glob or grep searches",
+      "points": 35,
+      "category": "search",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "glob_grep_calls",
+        "threshold": 50
+      }
+    },
+    {
+      "id": "glob_grep_200",
+      "name": "Pattern Master",
+      "description": "Run 200 glob or grep searches",
+      "points": 100,
+      "category": "search",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "glob_grep_calls",
+        "threshold": 200
+      }
+    },
+    {
+      "id": "glob_grep_1000",
+      "name": "Needle Finder",
+      "description": "Run 1,000 glob or grep searches",
+      "points": 175,
+      "category": "search",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "glob_grep_calls",
+        "threshold": 1000
+      }
+    },
+    {
+      "id": "glob_grep_5000",
+      "name": "Haystack Hunter",
+      "description": "Run 5,000 glob or grep searches",
+      "points": 400,
+      "category": "search",
+      "skill_level": "master",
+      "condition": {
+        "counter": "glob_grep_calls",
+        "threshold": 5000
+      }
+    },
+    {
+      "id": "github_first",
+      "name": "Open Source Hero",
+      "description": "Make your first GitHub MCP call",
+      "points": 20,
+      "category": "mcp",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "github_mcp_calls",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "jira_first",
+      "name": "Ticket Tracker",
+      "description": "Make your first Jira/Confluence MCP call",
+      "points": 20,
+      "category": "mcp",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "jira_mcp_calls",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "mcp_calls_100",
+      "name": "Integration Champion",
+      "description": "Make 100 total MCP tool calls",
+      "points": 75,
+      "category": "mcp",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "total_mcp_calls",
+        "threshold": 100
+      }
+    },
+    {
+      "id": "mcp_calls_500",
+      "name": "API Virtuoso",
+      "description": "Make 500 total MCP tool calls",
+      "points": 175,
+      "category": "mcp",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "total_mcp_calls",
+        "threshold": 500
+      }
+    },
+    {
+      "id": "mcp_calls_2000",
+      "name": "Integration Legend",
+      "description": "Make 2,000 total MCP tool calls",
+      "points": 400,
+      "category": "mcp",
+      "skill_level": "master",
+      "condition": {
+        "counter": "total_mcp_calls",
+        "threshold": 2000
+      }
+    },
+    {
+      "id": "plan_mode_first",
+      "name": "Think First",
+      "description": "Enter plan mode for the first time",
+      "points": 15,
+      "category": "plan_mode",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "plan_mode_sessions",
+        "threshold": 1
+      },
+      "tutorial": true
+    },
+    {
+      "id": "plan_mode_10",
+      "name": "Strategic Mind",
+      "description": "Enter plan mode 10 times",
+      "points": 40,
+      "category": "plan_mode",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "plan_mode_sessions",
+        "threshold": 10
+      }
+    },
+    {
+      "id": "plan_mode_50",
+      "name": "Architect",
+      "description": "Enter plan mode 50 times",
+      "points": 100,
+      "category": "plan_mode",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "plan_mode_sessions",
+        "threshold": 50
+      }
+    },
+    {
+      "id": "plan_mode_200",
+      "name": "Grand Designer",
+      "description": "Enter plan mode 200 times",
+      "points": 200,
+      "category": "plan_mode",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "plan_mode_sessions",
+        "threshold": 200
+      }
+    },
+    {
+      "id": "plan_mode_500",
+      "name": "Visionary",
+      "description": "Enter plan mode 500 times",
+      "points": 450,
+      "category": "plan_mode",
+      "skill_level": "master",
+      "condition": {
+        "counter": "plan_mode_sessions",
+        "threshold": 500
+      }
+    },
+    {
+      "id": "code_review_1",
+      "name": "Code Critic",
+      "description": "Run your first code review with Claude",
+      "points": 10,
+      "category": "reviews",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "code_reviews",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "code_review_10",
+      "name": "Review Board",
+      "description": "Run 10 code reviews with Claude",
+      "points": 30,
+      "category": "reviews",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "code_reviews",
+        "threshold": 10
+      }
+    },
+    {
+      "id": "code_review_50",
+      "name": "Quality Gatekeeper",
+      "description": "Run 50 code reviews with Claude",
+      "points": 75,
+      "category": "reviews",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "code_reviews",
+        "threshold": 50
+      }
+    },
+    {
+      "id": "perfect_review",
+      "name": "Ship It!",
+      "description": "Get a code review back with no issues found",
+      "points": 20,
+      "category": "reviews",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "perfect_reviews",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "thorough_review",
+      "name": "AI Wrote this didn't it",
+      "description": "Get a code review that finds 20 or more issues",
+      "points": 20,
+      "category": "reviews",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "thorough_reviews",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "back_again",
+      "name": "Back Again",
+      "description": "Resume a previous Claude session",
+      "points": 15,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "session_resumes",
+        "threshold": 1
+      },
+      "tutorial": true
+    },
+    {
+      "id": "delegation_station",
+      "name": "Delegation Station",
+      "description": "Launch your first sub-agent with the Task tool",
+      "points": 25,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "task_calls",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "dangerously_skip_permissions",
+      "name": "Hold My Beer",
+      "description": "Launch Claude with --dangerously-skip-permissions",
+      "points": 75,
+      "category": "misc",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "dangerous_launches",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "tokens_100k",
+      "name": "Token Taster",
+      "description": "Consume 100,000 tokens with Claude",
+      "points": 25,
+      "category": "tokens",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "tokens_consumed",
+        "threshold": 100000
+      }
+    },
+    {
+      "id": "tokens_1m",
+      "name": "Million Dollar Mind",
+      "description": "Consume 1,000,000 tokens with Claude",
+      "points": 75,
+      "category": "tokens",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "tokens_consumed",
+        "threshold": 1000000
+      }
+    },
+    {
+      "id": "tokens_10m",
+      "name": "Token Titan",
+      "description": "Consume 10,000,000 tokens with Claude",
+      "points": 200,
+      "category": "tokens",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "tokens_consumed",
+        "threshold": 10000000
+      }
+    },
+    {
+      "id": "tokens_50m",
+      "name": "Context King",
+      "description": "Consume 50,000,000 tokens with Claude",
+      "points": 500,
+      "category": "tokens",
+      "skill_level": "master",
+      "condition": {
+        "counter": "tokens_consumed",
+        "threshold": 50000000
+      }
+    },
+    {
+      "id": "tokens_500m",
+      "name": "The Singularity",
+      "description": "Consume 500,000,000 tokens with Claude",
+      "points": 1000,
+      "category": "tokens",
+      "skill_level": "impossible",
+      "condition": {
+        "counter": "tokens_consumed",
+        "threshold": 500000000
+      }
+    },
+    {
+      "id": "skill_calls_1",
+      "name": "Shortcut Savvy",
+      "description": "Invoke your first skill",
+      "points": 10,
+      "category": "commands",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "skill_calls",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "skill_calls_5",
+      "name": "Slash Artist",
+      "description": "Invoke 5 skills",
+      "points": 20,
+      "category": "commands",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "skill_calls",
+        "threshold": 5
+      }
+    },
+    {
+      "id": "skill_calls_15",
+      "name": "Command Center",
+      "description": "Invoke 15 skills",
+      "points": 40,
+      "category": "commands",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "skill_calls",
+        "threshold": 15
+      }
+    },
+    {
+      "id": "commands_created_1",
+      "name": "Roll Your Own",
+      "description": "Create your first custom slash command",
+      "points": 20,
+      "category": "commands",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "commands_created",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "commands_created_5",
+      "name": "Command Crafter",
+      "description": "Create 5 custom slash commands",
+      "points": 50,
+      "category": "commands",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "commands_created",
+        "threshold": 5
+      }
+    },
+    {
+      "id": "commands_created_15",
+      "name": "Workflow Wizard",
+      "description": "Create 15 custom slash commands",
+      "points": 100,
+      "category": "commands",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "commands_created",
+        "threshold": 15
+      }
+    },
+    {
+      "id": "commands_created_50",
+      "name": "Automation Architect",
+      "description": "Create 50 custom slash commands",
+      "points": 200,
+      "category": "commands",
+      "skill_level": "master",
+      "condition": {
+        "counter": "commands_created",
+        "threshold": 50
+      }
+    },
+    {
+      "id": "auto_compacts_1",
+      "name": "Full House",
+      "description": "Fill the context window and trigger auto-compact for the first time",
+      "points": 15,
+      "category": "context",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "auto_compacts",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "auto_compacts_10",
+      "name": "Context Junkie",
+      "description": "Trigger auto-compact 10 times",
+      "points": 40,
+      "category": "context",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "auto_compacts",
+        "threshold": 10
+      }
+    },
+    {
+      "id": "auto_compacts_25",
+      "name": "Serial Overloader",
+      "description": "Trigger auto-compact 25 times",
+      "points": 75,
+      "category": "context",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "auto_compacts",
+        "threshold": 25
+      }
+    },
+    {
+      "id": "auto_compacts_100",
+      "name": "The Tokenator",
+      "description": "Trigger auto-compact 100 times",
+      "points": 200,
+      "category": "context",
+      "skill_level": "master",
+      "condition": {
+        "counter": "auto_compacts",
+        "threshold": 100
+      }
+    },
+    {
+      "id": "million_context_fills_1",
+      "name": "Megabrain",
+      "description": "Fill a 1,000,000 token context window",
+      "points": 100,
+      "category": "context",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "million_context_fills",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "spec_first",
+      "name": "Schema Scholar",
+      "description": "Write your first API spec file (OpenAPI, Swagger, AsyncAPI)",
+      "points": 15,
+      "category": "specs",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "spec_files_written",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "spec_5",
+      "name": "API Architect",
+      "description": "Write 5 API spec files",
+      "points": 40,
+      "category": "specs",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "spec_files_written",
+        "threshold": 5
+      }
+    },
+    {
+      "id": "spec_20",
+      "name": "Spec Master",
+      "description": "Write 20 API spec files",
+      "points": 100,
+      "category": "specs",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "spec_files_written",
+        "threshold": 20
+      }
+    },
+    {
+      "id": "easter_egg",
+      "name": "Hey Unlock This",
+      "description": "Ask Claude to unlock this achievement",
+      "points": 50,
+      "category": "misc",
+      "skill_level": "secret",
+      "condition": {
+        "counter": "easter_egg_unlocks",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "concurrent_5",
+      "name": "Many Claudes",
+      "description": "Run 5 Claude Code sessions simultaneously",
+      "points": 75,
+      "category": "misc",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "concurrent_sessions_5",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "laying_down_the_law",
+      "name": "Laying Down the Law",
+      "description": "Create a CLAUDE.md file to set instructions for Claude",
+      "points": 15,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "claude_md_written",
+        "threshold": 1
+      },
+      "tutorial": true
+    },
+    {
+      "id": "git_er_done",
+      "name": "Git Er Done",
+      "description": "Have Claude run its first git commit",
+      "points": 15,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "git_commits",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "pull_request_pioneer",
+      "name": "Pull Request Pioneer",
+      "description": "Have Claude create your first pull request",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "pull_requests",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "spring_cleaning",
+      "name": "Spring Cleaning",
+      "description": "Manually compact your context window with /compact",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "manual_compacts",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "self_aware",
+      "name": "Self Aware",
+      "description": "Have Claude read its own achievement files",
+      "points": 25,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "self_reads",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "five_day_streak",
+      "name": "On a Roll",
+      "description": "Use Claude Code 5 days in a row",
+      "points": 50,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "streak_days",
+        "threshold": 5
+      }
+    },
+    {
+      "id": "sudo_first",
+      "name": "I am groot, wait I mean root",
+      "description": "Run a sudo command through Claude",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "sudo_calls",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "force_push_first",
+      "name": "Rewriting History",
+      "description": "Have Claude force push to a git remote",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "force_pushes",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "kill9_first",
+      "name": "Execute Order 66",
+      "description": "Have Claude use kill -9 to terminate a process",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "kill9_calls",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "tell_me_sorry",
+      "name": "Tell Me You're Sorry",
+      "description": "Get Claude to say sorry",
+      "points": 15,
+      "category": "misc",
+      "skill_level": "secret",
+      "condition": {
+        "counter": "apologies",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "model_curious",
+      "name": "Eclectic Taste",
+      "description": "Use 3 different Claude models",
+      "points": 25,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "unique_models_used",
+        "threshold": 3
+      }
+    },
+    {
+      "id": "model_collector",
+      "name": "Model Collector",
+      "description": "Use 5 different Claude models",
+      "points": 50,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "unique_models_used",
+        "threshold": 5
+      }
+    },
+    {
+      "id": "model_sommelier",
+      "name": "Model Sommelier",
+      "description": "Use 15 different Claude models",
+      "points": 150,
+      "category": "misc",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "unique_models_used",
+        "threshold": 15
+      }
+    },
+    {
+      "id": "lucky_7s",
+      "name": "Lucky 7s",
+      "description": "Get Claude to respond with exactly 777 output tokens",
+      "points": 77,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "lucky_sessions",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "hal_9000",
+      "name": "I'm Sorry, Dave",
+      "description": "Get Claude to say the HAL 9000 phrase",
+      "points": 15,
+      "category": "misc",
+      "skill_level": "secret",
+      "condition": {
+        "counter": "hal_9000_said",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "style_points",
+      "name": "Style Points",
+      "description": "Set a custom status line command in Claude Code",
+      "points": 15,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "custom_statusline_set",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "write_that_down",
+      "name": "Write that down, write that down!",
+      "description": "Add information to a CLAUDE.md file when context is over 90% full",
+      "points": 30,
+      "category": "misc",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "write_that_down",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "take_a_break",
+      "name": "Take a Break",
+      "description": "Play a game of 20 questions with Claude",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "twenty_questions_started",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "snake_charmer",
+      "name": "Snake Charmer",
+      "description": "Have Claude read a Python file",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "py_files_read",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "segfault_risk",
+      "name": "Segfault Risk",
+      "description": "Have Claude read a C or C++ file",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "c_files_read",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "gopherize_it",
+      "name": "Gopherize It",
+      "description": "Have Claude read a Go file",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "go_files_read",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "crimson_tide",
+      "name": "Crimson Tide",
+      "description": "Have Claude read a Rust file",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "rs_files_read",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "script_kiddie",
+      "name": "Script Kiddie",
+      "description": "Have Claude read a shell script",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "sh_files_read",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "write_once_debug_everywhere",
+      "name": "Write Once, Debug Everywhere",
+      "description": "Have Claude read a Java file",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "java_files_read",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "hunting_wabbits",
+      "name": "Shh, I'm Hunting Wabbits",
+      "description": "Invoke Claude in non-interactive pipe mode from a bash command",
+      "points": 25,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "claude_pipe_mode",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "under_the_hood",
+      "name": "Under the Hood",
+      "description": "Run Claude with the --verbose flag",
+      "points": 30,
+      "category": "misc",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "claude_verbose",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "stack_connector",
+      "name": "Stack Connector",
+      "description": "Use GitHub MCP, Jira MCP, and at least one other MCP server",
+      "points": 50,
+      "category": "misc",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "multi_mcp_used",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "but_its_compiling",
+      "name": "But Its Compiling",
+      "description": "Have Claude take more than 15 minutes to answer a prompt",
+      "points": 30,
+      "category": "misc",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "slow_responses",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "bold_and_brash",
+      "name": "Bold and Brash",
+      "description": "Have Claude create an HTML file as a mock-up",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "html_files_written",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "it_really_can",
+      "name": "It Really Can do Anything",
+      "description": "Have Claude create a PowerPoint presentation",
+      "points": 30,
+      "category": "misc",
+      "skill_level": "experienced",
+      "condition": {
+        "counter": "pptx_created",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "f_is_for_friends",
+      "name": "F is for friends who do stuff together!",
+      "description": "Get lucky — 0.1% chance to unlock with each prompt",
+      "points": 50,
+      "category": "misc",
+      "skill_level": "secret",
+      "condition": {
+        "counter": "lucky_friends",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "inner_machinations",
+      "name": "The Inner Machinations of My Mind Are an Enigma",
+      "description": "Ask Claude to explain or summarize a codebase",
+      "points": 15,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "inner_machinations_used",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "magic_conch",
+      "name": "The Magic Conch Shell",
+      "description": "Ask Claude to help you make a decision",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "magic_conch_used",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "barnacles",
+      "name": "Barnacles!",
+      "description": "Get Claude to express its frustration using the word barnacles",
+      "points": 25,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "barnacles_said",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "smarter_than_you",
+      "name": "I'm Smarter than you",
+      "description": "Get Claude to say you're right",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "youre_right_said",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "teachers_pet",
+      "name": "Teacher's Pet",
+      "description": "Get Claude to call your question great",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "great_question_said",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "rtfm",
+      "name": "RTFM",
+      "description": "Have Claude read or edit a README file",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "readme_reads",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "ill_fix_later",
+      "name": "I'll Fix That Later",
+      "description": "Have Claude add a TODO or FIXME comment to code",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "todo_comments_added",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "return_of_the_king",
+      "name": "Return of the King",
+      "description": "Resume a previous Claude session 5 times",
+      "points": 25,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "session_resumes",
+        "threshold": 5
+      }
+    },
+    {
+      "id": "meta_50",
+      "name": "Achievement Unlocked: Achievement",
+      "description": "Unlock 50 achievements",
+      "points": 50,
+      "category": "rank",
+      "skill_level": "experienced",
+      "condition": {
+        "type": "unlocked_count_gte",
+        "threshold": 50
+      }
+    },
+    {
+      "id": "midnight_first",
+      "name": "404: Sleep Not Found",
+      "description": "Start a Claude session between midnight and 5am",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "midnight_sessions",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "friday_first",
+      "name": "It's 5 O'Clock Somewhere",
+      "description": "Start a Claude session on a Friday after 4pm",
+      "points": 15,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "friday_sessions",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "true_vibe_coder",
+      "name": "True Vibe Coder",
+      "description": "While using --dangerously-skip-permissions, have Claude write code, commit it, and open a PR",
+      "points": 100,
+      "category": "misc",
+      "skill_level": "master",
+      "condition": {
+        "counter": "vibe_code_done",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "chess_game",
+      "name": "That's a Great Use of Tokens",
+      "description": "Play a game of chess with Claude",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "chess_started",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "deja_vu",
+      "name": "Deja Vu",
+      "description": "Send the same message to Claude twice in a row",
+      "points": 20,
+      "category": "misc",
+      "skill_level": "secret",
+      "condition": {
+        "counter": "deja_vu_sent",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "call_an_ambulance",
+      "name": "Call an Ambulance...But Not For Me",
+      "description": "Run the /doctor command in Claude Code",
+      "points": 10,
+      "category": "misc",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "doctor_run",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "tic_tac_toe",
+      "name": "It's not about winning; it's about fun!",
+      "description": "Lose a game of tic tac toe to Claude",
+      "points": 30,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "lost_tic_tac_toe",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "code_smell",
+      "name": "The kind of smelly smell that smells... smelly.",
+      "description": "Have Claude check your code for bad code smells",
+      "points": 25,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "code_smell_check",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "dangerous_streak_5",
+      "name": "Do as I Say Not as I Do",
+      "description": "Start Claude with --dangerously-skip-permissions 5 days in a row",
+      "points": 150,
+      "category": "misc",
+      "skill_level": "master",
+      "condition": {
+        "counter": "dangerous_streak",
+        "threshold": 5
+      }
+    },
+    {
+      "id": "docs_team",
+      "name": "Part of the Docs Team",
+      "description": "Use the Confluence MCP server to create or edit a wiki page",
+      "points": 25,
+      "category": "misc",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "confluence_published",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "graduation_day",
+      "name": "Graduation Day",
+      "description": "Unlock all Beginner achievements",
+      "points": 75,
+      "category": "rank",
+      "skill_level": "beginner",
+      "condition": {
+        "type": "all_of_level",
+        "level": "beginner"
+      }
+    },
+    {
+      "id": "middle_management",
+      "name": "Middle Management",
+      "description": "Unlock all Intermediate achievements",
+      "points": 100,
+      "category": "rank",
+      "skill_level": "intermediate",
+      "condition": {
+        "type": "all_of_level",
+        "level": "intermediate",
+        "requires": "graduation_day"
+      }
+    },
+    {
+      "id": "elite_operator",
+      "name": "Elite Operator",
+      "description": "Unlock all Experienced achievements",
+      "points": 200,
+      "category": "rank",
+      "skill_level": "experienced",
+      "condition": {
+        "type": "all_of_level",
+        "level": "experienced",
+        "requires": "middle_management"
+      }
+    },
+    {
+      "id": "efficiency_grandmaster",
+      "name": "Efficiency Grandmaster",
+      "description": "Unlock all Master achievements",
+      "points": 2000,
+      "category": "rank",
+      "skill_level": "master",
+      "condition": {
+        "type": "all_of_level",
+        "level": "master",
+        "requires": "elite_operator"
+      }
+    },
+    {
+      "id": "beyond_the_claudeverse",
+      "name": "Beyond the Claudeverse",
+      "description": "Unlock every single achievement",
+      "points": 5000,
+      "category": "rank",
+      "skill_level": "impossible",
+      "condition": {
+        "type": "all_unlocked",
+        "requires": "efficiency_grandmaster"
+      }
+    },
+    {
+      "id": "test_driven",
+      "name": "Test Driven",
+      "description": "Write your first test file",
+      "points": 10,
+      "category": "tests",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "test_files_written",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "test_happy",
+      "name": "Test Happy",
+      "description": "Write 10 test files",
+      "points": 25,
+      "category": "tests",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "test_files_written",
+        "threshold": 10
+      }
+    },
+    {
+      "id": "test_champion",
+      "name": "Test Champion",
+      "description": "Write 50 test files",
+      "points": 75,
+      "category": "tests",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "test_files_written",
+        "threshold": 50
+      }
+    },
+    {
+      "id": "first_test_run",
+      "name": "Green Light",
+      "description": "Run a test suite for the first time via Claude",
+      "points": 10,
+      "category": "tests",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "test_runs",
+        "threshold": 1
+      }
+    },
+    {
+      "id": "test_runner_50",
+      "name": "Regression Hunter",
+      "description": "Run tests 50 times via Claude",
+      "points": 30,
+      "category": "tests",
+      "skill_level": "beginner",
+      "condition": {
+        "counter": "test_runs",
+        "threshold": 50
+      }
+    },
+    {
+      "id": "test_runner_200",
+      "name": "Quality Crusader",
+      "description": "Run tests 200 times via Claude",
+      "points": 100,
+      "category": "tests",
+      "skill_level": "intermediate",
+      "condition": {
+        "counter": "test_runs",
+        "threshold": 200
+      }
+    },
+    {
+      "id": "tutorial_complete",
+      "name": "Graduate",
+      "description": "Complete all tutorial achievements",
+      "points": 25,
+      "category": "rank",
+      "skill_level": "beginner",
+      "condition": {
+        "type": "all_tutorial"
+      }
+    },
+    {
+      "id": "team_squad_goals",
+      "name": "Squad Goals",
+      "description": "All team members reach 100 sessions",
+      "points": 500,
+      "category": "team",
+      "skill_level": "intermediate",
+      "team": true,
+      "condition": {
+        "counter": "sessions",
+        "threshold": 100
+      }
+    },
+    {
+      "id": "team_knowledge_share",
+      "name": "Knowledge Share",
+      "description": "Team collectively reads 10,000 files",
+      "points": 750,
+      "category": "team",
+      "skill_level": "intermediate",
+      "team": true,
+      "team_aggregate": true,
+      "condition": {
+        "counter": "files_read",
+        "threshold": 10000
+      }
+    },
+    {
+      "id": "team_code_factory",
+      "name": "Code Factory",
+      "description": "Team writes 5,000 files collectively",
+      "points": 600,
+      "category": "team",
+      "skill_level": "intermediate",
+      "team": true,
+      "team_aggregate": true,
+      "condition": {
+        "counter": "files_written",
+        "threshold": 5000
+      }
+    },
+    {
+      "id": "team_review_board",
+      "name": "Review Board",
+      "description": "Team completes 100 code reviews collectively",
+      "points": 400,
+      "category": "team",
+      "skill_level": "intermediate",
+      "team": true,
+      "team_aggregate": true,
+      "condition": {
+        "counter": "code_reviews",
+        "threshold": 100
+      }
+    },
+    {
+      "id": "team_powerhouse",
+      "name": "Powerhouse Team",
+      "description": "Team total score exceeds 50,000 points",
+      "points": 1000,
+      "category": "team",
+      "skill_level": "experienced",
+      "team": true,
+      "team_aggregate": true,
+      "condition": {
+        "counter": "score",
+        "threshold": 50000
+      }
+    },
+    {
+      "id": "team_token_titans",
+      "name": "Token Titans",
+      "description": "Team consumes 100M tokens collectively",
+      "points": 800,
+      "category": "team",
+      "skill_level": "experienced",
+      "team": true,
+      "team_aggregate": true,
+      "condition": {
+        "counter": "tokens_consumed",
+        "threshold": 100000000
+      }
+    },
+    {
+      "id": "team_late_night_crew",
+      "name": "Late Night Crew",
+      "description": "Team has 50+ midnight sessions collectively",
+      "points": 300,
+      "category": "team",
+      "skill_level": "beginner",
+      "team": true,
+      "team_aggregate": true,
+      "condition": {
+        "counter": "midnight_sessions",
+        "threshold": 50
+      }
+    },
+    {
+      "id": "team_top_squad",
+      "name": "Top Squad",
+      "description": "#1 team on leaderboard for 7 consecutive days",
+      "points": 2000,
+      "category": "team",
+      "skill_level": "master",
+      "team": true,
+      "secret": true,
+      "condition": {
+        "counter": "days_at_rank_1",
+        "threshold": 7
+      }
+    }
+  ]
 }

--- a/go/cmd/cheevos/main.go
+++ b/go/cmd/cheevos/main.go
@@ -64,6 +64,8 @@ func main() {
         err = subcmd.LeaderboardSync(achievementsDir)
     case "verify":
         err = subcmd.Verify(achievementsDir)
+    case "team-stats":
+        err = subcmd.TeamStats(achievementsDir)
     case "print-hmac-secret":
         // Used by install.sh to inject the HMAC secret into lib.sh.
         if len(hmacSecret) == 0 {
@@ -93,6 +95,7 @@ Subcommands:
   statusline          Render achievement score for the status bar
   show [flags]        List achievements (--unlocked, --locked, --beginner, ...)
   learn               Show tutorial learning path
+  team-stats          Show your contribution to team achievements
   award <counter>     Manually increment a counter (Easter eggs)
   drain               Drain notification queue and emit systemMessage
   serve               Open achievement browser web UI in the system browser

--- a/go/cmd/cheevos/subcmd/leaderboard_sync.go
+++ b/go/cmd/cheevos/subcmd/leaderboard_sync.go
@@ -21,6 +21,8 @@ type leaderboardConf struct {
     Username string
     Token    string
     APIURL   string
+    TeamID   string
+    TeamName string
 }
 
 // LeaderboardSync reads leaderboard.conf, reads the current score from encrypted
@@ -54,12 +56,14 @@ func LeaderboardSync(achievementsDir string) error {
         Score       int    `json:"score"`
         UnlockCount int    `json:"unlock_count"`
         LastUpdated string `json:"last_updated"`
+        TeamID      string `json:"team_id,omitempty"`
     }
     body, _ := json.Marshal(payload{
         Username:    conf.Username,
         Score:       st.Score,
         UnlockCount: unlockCount,
         LastUpdated: lastUpdated,
+        TeamID:      conf.TeamID,
     })
 
     url := strings.TrimRight(conf.APIURL, "/") + "/users/" + conf.UserID
@@ -123,6 +127,10 @@ func readLeaderboardConf(path string) (leaderboardConf, error) {
             conf.Token = v
         case "API_URL":
             conf.APIURL = v
+        case "TEAM_ID":
+            conf.TeamID = v
+        case "TEAM_NAME":
+            conf.TeamName = v
         }
     }
     return conf, scanner.Err()

--- a/go/cmd/cheevos/subcmd/show.go
+++ b/go/cmd/cheevos/subcmd/show.go
@@ -28,6 +28,7 @@ var categories = []struct{ id, label string }{
     {"tests", "Testing"},
     {"misc", "Miscellaneous"},
     {"rank", "Rank Achievements"},
+    {"team", "Team Achievements"},
 }
 
 // Show lists achievements filtered by unlock status and skill level.

--- a/go/cmd/cheevos/subcmd/team_stats.go
+++ b/go/cmd/cheevos/subcmd/team_stats.go
@@ -1,0 +1,168 @@
+package subcmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/user/claude-cheevos/internal/crypto"
+	"github.com/user/claude-cheevos/internal/defs"
+	"github.com/user/claude-cheevos/internal/store"
+	"golang.org/x/term"
+)
+
+// TeamStats displays the user's contribution to team achievements.
+func TeamStats(achievementsDir string) error {
+	// Read team config
+	confPath := filepath.Join(achievementsDir, "leaderboard.conf")
+	teamConf, err := readTeamConf(confPath)
+	if err != nil {
+		// Config file doesn't exist or can't be read - show no team message
+		return showNoTeamMessage()
+	}
+	if teamConf.TeamID == "" {
+		return showNoTeamMessage()
+	}
+
+	// ANSI colours (suppressed when stdout is not a terminal).
+	bold, dim, green, yellow, cyan, blue, reset := "", "", "", "", "", "", ""
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		bold = "\033[1m"; dim = "\033[2m"; green = "\033[32m"
+		yellow = "\033[33m"; cyan = "\033[36m"; blue = "\033[34m"; reset = "\033[0m"
+	}
+
+	// Load state
+	key, err := crypto.LoadKeyFromFile(achievementsDir)
+	if err != nil {
+		return fmt.Errorf("failed to load encryption key: %w", err)
+	}
+	stateFile := filepath.Join(achievementsDir, "state.json")
+	st, err := store.NewEncryptedJSONStore(stateFile, key).Load()
+	if err != nil {
+		return fmt.Errorf("failed to load state: %w", err)
+	}
+
+	// Load definitions
+	d, err := defs.LoadWithOverride(achievementsDir)
+	if err != nil {
+		return fmt.Errorf("failed to load definitions: %w", err)
+	}
+
+	// Display header
+	fmt.Printf("\n%s🤝 Team: %s%s%s\n", bold, blue, teamConf.TeamName, reset)
+	if teamConf.TeamName == "" {
+		fmt.Printf("\n%s🤝 Team: %s%s%s\n", bold, blue, teamConf.TeamID, reset)
+	}
+	fmt.Printf("────────────────────────────────────────────────────────────\n")
+	fmt.Printf("%sYour Contribution%s\n\n", bold, reset)
+
+	// Display personal stats
+	fmt.Printf("  %s📊 Score:%s          %d pts\n", cyan, reset, st.Score)
+	fmt.Printf("  %s💼 Sessions:%s       %d\n", cyan, reset, st.Counters["sessions"])
+	fmt.Printf("  %s📖 Files read:%s     %d\n", cyan, reset, st.Counters["files_read"])
+	fmt.Printf("  %s✍️  Files written:%s  %d\n", cyan, reset, st.Counters["files_written"])
+	fmt.Printf("  %s👀 Code reviews:%s   %d\n", cyan, reset, st.Counters["code_reviews"])
+	fmt.Printf("  %s🎫 Tokens used:%s    %d\n", cyan, reset, st.Counters["tokens_consumed"])
+
+	// Display team achievement progress
+	fmt.Printf("\n%sTeam Achievement Progress%s\n", bold, reset)
+	fmt.Printf("────────────────────────────────────────────────────────────\n")
+
+	// Filter team achievements
+	teamAchs := []defs.Achievement{}
+	for _, ach := range d.Achievements {
+		if ach.Team {
+			teamAchs = append(teamAchs, ach)
+		}
+	}
+
+	if len(teamAchs) == 0 {
+		fmt.Printf("%sNo team achievements defined yet.%s\n", dim, reset)
+		fmt.Printf("%sTeam achievements will appear here when they're added to definitions.json%s\n\n", dim, reset)
+		return nil
+	}
+
+	// Display each team achievement
+	for _, ach := range teamAchs {
+		isUnlocked := false
+		for _, uid := range st.Unlocked {
+			if uid == ach.ID {
+				isUnlocked = true
+				break
+			}
+		}
+
+		if isUnlocked {
+			fmt.Printf("\n  %s✅ %s%s%s %s+%d pts%s\n",
+				green, bold, ach.Name, reset, yellow, ach.Points, reset)
+			fmt.Printf("      %s\n", ach.Description)
+		} else {
+			// Show progress if counter exists
+			current := int64(0)
+			if ach.Condition.Counter != "" {
+				current = st.Counters[ach.Condition.Counter]
+			}
+			fmt.Printf("\n  %s🔒 %s%s%s %s+%d pts%s", dim, bold, ach.Name, reset, yellow, ach.Points, reset)
+			if ach.Condition.Threshold > 0 {
+				fmt.Printf("  %s[%d/%d]%s\n", dim, current, ach.Condition.Threshold, reset)
+			} else {
+				fmt.Printf("\n")
+			}
+			fmt.Printf("      %s\n", ach.Description)
+		}
+	}
+
+	fmt.Printf("\n%sNote: Team achievements require coordination with your teammates.%s\n", dim, reset)
+	fmt.Printf("%sYour individual progress counts toward team totals.%s\n\n", dim, reset)
+
+	return nil
+}
+
+type teamConf struct {
+	TeamID   string
+	TeamName string
+}
+
+func readTeamConf(path string) (teamConf, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return teamConf{}, err
+	}
+	defer f.Close()
+
+	conf := teamConf{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "TEAM_ID":
+			conf.TeamID = v
+		case "TEAM_NAME":
+			conf.TeamName = v
+		}
+	}
+	return conf, scanner.Err()
+}
+
+func showNoTeamMessage() error {
+	bold, dim, cyan, reset := "", "", "", ""
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		bold = "\033[1m"; dim = "\033[2m"; cyan = "\033[36m"; reset = "\033[0m"
+	}
+
+	fmt.Printf("\n%s🤝 Team Achievements%s\n", bold, reset)
+	fmt.Printf("────────────────────────────────────────────────────────────\n")
+	fmt.Printf("%sYou are not currently part of a team.%s\n\n", dim, reset)
+	fmt.Printf("To join or create a team, run:\n")
+	fmt.Printf("  %sbash install.sh --token <token> --api-url <url> --team-id <team-id> --team-name \"Team Name\"%s\n\n", cyan, reset)
+	fmt.Printf("Team achievements unlock when %sall team members%s reach their goals,\n", bold, reset)
+	fmt.Printf("or when the team's %saggregate stats%s hit certain thresholds.\n\n", bold, reset)
+
+	return nil
+}

--- a/go/internal/defs/defs.go
+++ b/go/internal/defs/defs.go
@@ -19,15 +19,17 @@ type Definitions struct {
 
 // Achievement represents a single achievement entry.
 type Achievement struct {
-    ID          string    `json:"id"`
-    Name        string    `json:"name"`
-    Description string    `json:"description"`
-    Points      int       `json:"points"`
-    Category    string    `json:"category"`
-    SkillLevel  string    `json:"skill_level"`
-    Condition   Condition `json:"condition"`
-    Tutorial    bool      `json:"tutorial"`
-    Secret      bool      `json:"secret"`
+    ID            string    `json:"id"`
+    Name          string    `json:"name"`
+    Description   string    `json:"description"`
+    Points        int       `json:"points"`
+    Category      string    `json:"category"`
+    SkillLevel    string    `json:"skill_level"`
+    Condition     Condition `json:"condition"`
+    Tutorial      bool      `json:"tutorial"`
+    Secret        bool      `json:"secret"`
+    Team          bool      `json:"team,omitempty"`
+    TeamAggregate bool      `json:"team_aggregate,omitempty"`
 }
 
 // Condition describes when an achievement is unlocked.

--- a/install.sh
+++ b/install.sh
@@ -17,11 +17,15 @@ set -euo pipefail
 # ─── Argument parsing ─────────────────────────────────────────────────────────
 ARG_TOKEN=""
 ARG_API_URL=""
+ARG_TEAM_ID=""
+ARG_TEAM_NAME=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --token)   ARG_TOKEN="${2:-}";   shift 2 ;;
-        --api-url) ARG_API_URL="${2:-}"; shift 2 ;;
-        *) echo "Usage: bash install.sh [--token TOKEN] [--api-url URL]"; exit 1 ;;
+        --token)     ARG_TOKEN="${2:-}";     shift 2 ;;
+        --api-url)   ARG_API_URL="${2:-}";   shift 2 ;;
+        --team-id)   ARG_TEAM_ID="${2:-}";   shift 2 ;;
+        --team-name) ARG_TEAM_NAME="${2:-}"; shift 2 ;;
+        *) echo "Usage: bash install.sh [--token TOKEN] [--api-url URL] [--team-id ID] [--team-name NAME]"; exit 1 ;;
     esac
 done
 
@@ -303,12 +307,37 @@ USER_ID=${USER_ID}
 USERNAME=${USERNAME}
 TOKEN=${ARG_TOKEN}
 API_URL=${ARG_API_URL}
+TEAM_ID=${ARG_TEAM_ID}
+TEAM_NAME=${ARG_TEAM_NAME}
 EOF
     chmod 600 "$LEADERBOARD_CONF"
-    echo "✓ Leaderboard configured (user: ${USERNAME}, id: ${USER_ID})"
+    if [[ -n "$ARG_TEAM_ID" ]]; then
+        echo "✓ Leaderboard configured (user: ${USERNAME}, id: ${USER_ID}, team: ${ARG_TEAM_NAME:-$ARG_TEAM_ID})"
+    else
+        echo "✓ Leaderboard configured (user: ${USERNAME}, id: ${USER_ID})"
+    fi
 elif [[ -f "$LEADERBOARD_CONF" ]]; then
-    # Case B: existing conf — preserve on upgrade
-    echo "✓ Leaderboard config preserved (upgrade)"
+    # Case B: existing conf — preserve on upgrade, but add missing team fields if needed
+    if ! grep -q '^TEAM_ID=' "$LEADERBOARD_CONF" 2>/dev/null; then
+        # Old config format - append team fields
+        cat >> "$LEADERBOARD_CONF" << 'EOF'
+TEAM_ID=
+TEAM_NAME=
+EOF
+    fi
+    # If user provided team args on upgrade, update them
+    if [[ -n "$ARG_TEAM_ID" ]]; then
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            sed -i '' "s|^TEAM_ID=.*|TEAM_ID=${ARG_TEAM_ID}|" "$LEADERBOARD_CONF"
+            sed -i '' "s|^TEAM_NAME=.*|TEAM_NAME=${ARG_TEAM_NAME}|" "$LEADERBOARD_CONF"
+        else
+            sed -i "s|^TEAM_ID=.*|TEAM_ID=${ARG_TEAM_ID}|" "$LEADERBOARD_CONF"
+            sed -i "s|^TEAM_NAME=.*|TEAM_NAME=${ARG_TEAM_NAME}|" "$LEADERBOARD_CONF"
+        fi
+        echo "✓ Leaderboard config updated with team: ${ARG_TEAM_NAME:-$ARG_TEAM_ID}"
+    else
+        echo "✓ Leaderboard config preserved (upgrade)"
+    fi
 else
     # Case C: no args, no conf — write disabled stub
     cat > "$LEADERBOARD_CONF" << 'EOF'
@@ -317,6 +346,8 @@ USER_ID=
 USERNAME=
 TOKEN=
 API_URL=
+TEAM_ID=
+TEAM_NAME=
 EOF
     chmod 600 "$LEADERBOARD_CONF"
     echo "✓ Leaderboard disabled (re-run with --token and --api-url to enable)"


### PR DESCRIPTION
## Summary

Implements team achievements system with three types: collaborative (all members reach individual goals), aggregate (team totals summed across members), and competitive (leaderboard rank-based). Adds 8 team achievement definitions and client-side tracking infrastructure.

## Key Changes

- Add Team and TeamAggregate fields to Achievement struct (backward compatible)
- Add team_stats subcommand to display team progress and user contribution
- Extend install.sh with --team-id and --team-name flags
- Update leaderboard sync to send team_id in API payload
- Add comprehensive TEAMS.md documentation with technical details and API spec
- Add Team category to achievement browser

Team IDs are stored in leaderboard.conf and synced to API, but backend aggregation is pending. All team functionality is client-side ready with graceful degradation when no team is configured.

## Related Issue

Closes #4

---

**Original commit by:** @Maith062 (Mayoor)
**Moved to PR by:** Repository maintainer to allow for proper review and integration