### PR TITLE
Fix million_context_fills detection in pre-compact hook

### DIFF
--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -33,12 +33,12 @@ COUNTER_UPDATES='{"auto_compacts": 1}'
 
 # Check if this session filled a 1M-token context window.
 if [[ -n "$TRANSCRIPT_PATH" && -f "$TRANSCRIPT_PATH" ]]; then
-    MAX_CONTEXT=$(jq -rs '
+    MAX_CONTEXT=$(jq -Rc 'try fromjson catch empty' "$TRANSCRIPT_PATH" 2>/dev/null | jq -rs '
         [.[] | select(.type == "assistant") | .message.usage.input_tokens // 0] |
         max // 0
-    ' "$TRANSCRIPT_PATH" 2>/dev/null || echo 0)
+    ' 2>/dev/null || echo 0)
 
-    if (( MAX_CONTEXT >= 1000000 )); then
+    if (( MAX_CONTEXT >= 850000 )); then
         COUNTER_UPDATES='{"auto_compacts": 1, "million_context_fills": 1}'
     fi
 fi


### PR DESCRIPTION
- Add JSONL pre-filtering via `jq -Rc 'try fromjson catch empty'` before the main jq pass, preventing silent failures on large/partially-written transcript files (same pattern stop.sh already uses)
- Lower detection threshold from 1,000,000 to 850,000 tokens to account for auto-compact firing before the hard context ceiling is reached