### PR TITLE
Fix Style Points achievement not unlocking post-install

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -105,8 +105,24 @@ fi
 
 export _COUNTER_SETS="{\"streak_days\": ${NEW_STREAK}, \"last_session_epoch\": ${TODAY_EPOCH}, \"dangerous_streak\": ${NEW_DANGER_STREAK}}"
 
-# Style Points — user had a custom statusLine configured before cheevos install
-if [[ -s "$ACHIEVEMENTS_DIR/.original-statusline" ]]; then
+# Style Points — user has a custom statusLine configured
+# Check the saved file (install-time) first, then fall back to reading
+# settings.json directly to catch post-install customisation (issue #56).
+ORIGINAL_SAVE="$ACHIEVEMENTS_DIR/.original-statusline"
+HAS_CUSTOM_STATUSLINE=false
+if [[ -s "$ORIGINAL_SAVE" ]]; then
+    HAS_CUSTOM_STATUSLINE=true
+else
+    SETTINGS_FILE="$HOME/.claude/settings.json"
+    if [[ -f "$SETTINGS_FILE" ]]; then
+        CURRENT_CMD=$(jq -r '.statusLine.command // ""' "$SETTINGS_FILE")
+        CHEEVOS_DEFAULT="$ACHIEVEMENTS_DIR/cheevos statusline"
+        if [[ -n "$CURRENT_CMD" ]] && [[ "$CURRENT_CMD" != "$CHEEVOS_DEFAULT" ]]; then
+            HAS_CUSTOM_STATUSLINE=true
+        fi
+    fi
+fi
+if [[ "$HAS_CUSTOM_STATUSLINE" == "true" ]]; then
     UPDATES=$(printf '%s' "$UPDATES" | jq '. + {"custom_statusline_set": 1}')
 fi
 


### PR DESCRIPTION
## Summary

Fixes #56 — the "Style Points" achievement was permanently locked for users who set a custom `statusLine` **after** installing cheevos.

**Root cause:** The session-start hook only checked `.original-statusline`, which is written at install time. If no custom statusline existed when cheevos was installed, the file stays empty (0 bytes) and the `[[ -s ... ]]` check never passes — even if the user later customises their statusline.

**Fix:** Added a fallback path that reads `~/.claude/settings.json` directly and compares the current `statusLine.command` against the cheevos default (`$ACHIEVEMENTS_DIR/cheevos statusline`). If they differ, the user has customised their statusline post-install and the `custom_statusline_set` counter fires.

### Scenarios handled

| Scenario | Before | After |
|---|---|---|
| Custom statusline **before** install | Works (`.original-statusline` populated) | Works (unchanged path) |
| Custom statusline **after** install | **Never unlocks** | Works (settings.json fallback) |
| No custom statusline at all | Correctly locked | Correctly locked (no false positive) |
| Cheevos statusline fully replaced | Never unlocks | Works (command differs from default) |

## Test plan

- [ ] Syntax check: `bash -n hooks/session-start.sh` passes
- [ ] Fresh install with no prior statusline → achievement stays locked
- [ ] Edit `settings.json` to change `statusLine.command` to something custom → next session startup unlocks "Style Points"
- [ ] User who had custom statusline before install → still works via `.original-statusline` path