### PR TITLE
Fix concurrent session detection failing on macOS

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -61,7 +61,7 @@ fi
 UPDATES='{"sessions": 1}'
 
 # Concurrent session detection
-CLAUDE_COUNT=$(pgrep -f "[/]claude$" 2>/dev/null | wc -l | tr -d '[:space:]') || CLAUDE_COUNT=1
+CLAUDE_COUNT=$(pgrep -x claude 2>/dev/null | wc -l | tr -d '[:space:]') || CLAUDE_COUNT=1
 if (( CLAUDE_COUNT >= 5 )); then
     UPDATES=$(printf '%s' "$UPDATES" | jq '. + {"concurrent_sessions_5": 1}')
 fi


### PR DESCRIPTION
## Summary

Fixes #54 — the "Many Claudes" achievement (concurrent_sessions_5) could never unlock on macOS because the `pgrep` pattern failed to match any Claude processes.

**Root cause:** `pgrep -f "[/]claude$"` has two problems on macOS:
1. `[/]` requires a path prefix (e.g. `/usr/local/bin/claude`), but `pgrep` on macOS shows process names without paths
2. The `$` end anchor fails when the process has CLI arguments (e.g. `claude --dangerously-skip-permissions`)

Result: 0 processes detected even with 7+ concurrent sessions.

**Fix:** Replace with `pgrep -x claude` which matches the exact process name "claude" regardless of arguments or path display, and naturally excludes unrelated processes like `claude-helper` or `cheevos`.

## Test plan

- [ ] Syntax check: `bash -n hooks/session-start.sh` passes
- [ ] Run `pgrep -x claude` on macOS with multiple Claude sessions open — returns correct count
- [ ] Start 5+ Claude sessions → "Many Claudes" achievement unlocks on next session start
- [ ] Verify no false positives: `pgrep -x claude` does not match `claude-helper`, `cheevos`, or `Claude.app`