### PR TITLE
Create option to disable auto-updates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,10 +20,13 @@ cheevos/
 ├── scripts/
 │   └── lib.sh                   # Shared library: paths, HMAC helpers, _CHEEVOS_HMAC_SECRET
 ├── commands/
-│   ├── achievements.md          # /achievements slash command — runs cheevos serve, opens browser
-│   ├── achievements-tutorial.md # /achievements-tutorial slash command — interactive guided tour
-│   ├── achievements-version.md  # /achievements-version slash command — reports installed version
-│   └── uninstall-achievements.md # /uninstall-achievements slash command — interactive uninstall
+│   ├── achievements.md              # /achievements slash command — runs cheevos serve, opens browser
+│   ├── achievements-tutorial.md     # /achievements-tutorial slash command — interactive guided tour
+│   ├── achievements-version.md      # /achievements-version slash command — reports installed version
+│   ├── achievements-update.md       # /achievements-update slash command — force update check
+│   ├── achievements-enable-update.md  # /achievements-enable-update slash command — re-enable auto-updates
+│   ├── achievements-disable-update.md # /achievements-disable-update slash command — disable auto-updates
+│   └── uninstall-achievements.md    # /uninstall-achievements slash command — interactive uninstall
 ├── go/                          # Go source for the cheevos binary
 │   ├── go.mod / go.sum
 │   ├── Makefile                 # cross-compile matrix (requires CHEEVOS_HMAC_KEY env var)
@@ -72,6 +75,7 @@ Installed runtime lives at `~/.claude/achievements/` (state never touched on rei
 | `state.lock` | Advisory lockfile (never delete manually) |
 | `.version` | Installed version string — used by install.sh for upgrade detection |
 | `.original-statusline` | Prior `statusLine.command` value saved for uninstall restoration |
+| `.no-auto-update` | Optional flag file — when present, disables automatic update checks on session start. Created by `--no-auto-update` install flag or `/achievements-disable-update`. Removed by `/achievements-enable-update`. |
 | `hooks/` | Hook scripts copied from repo (safe to overwrite on upgrade) |
 | `scripts/lib.sh` | Shared library sourced by all hooks (HMAC secret injected at install time) |
 | `uninstall.sh` | Copy of uninstall.sh — referenced by `/uninstall-achievements` slash command |
@@ -85,6 +89,9 @@ Slash commands are installed to `~/.claude/commands/` (not inside `achievements/
 | `~/.claude/commands/achievements.md` | `/achievements` — runs `cheevos serve` in background, opens browser |
 | `~/.claude/commands/achievements-tutorial.md` | `/achievements-tutorial` — interactive guided tour for new users (17 tutorial achievements) |
 | `~/.claude/commands/achievements-version.md` | `/achievements-version` — reports the installed version string |
+| `~/.claude/commands/achievements-update.md` | `/achievements-update` — force-runs `cheevos check-updates --force` |
+| `~/.claude/commands/achievements-enable-update.md` | `/achievements-enable-update` — removes `.no-auto-update` flag to re-enable auto-updates |
+| `~/.claude/commands/achievements-disable-update.md` | `/achievements-disable-update` — creates `.no-auto-update` flag to disable auto-updates |
 | `~/.claude/commands/uninstall-achievements.md` | `/uninstall-achievements` — interactive uninstall with leaderboard warning |
 
 ## Install and Test
@@ -619,19 +626,28 @@ Only `scripts/lib.sh` is installed from the `scripts/` directory — it is sourc
 and must stay there. Do not add new utility scripts; call the binary directly instead.
 
 **Phase 1.6 — Slash commands:** copies `commands/achievements.md`,
-`commands/achievements-tutorial.md`, `commands/achievements-version.md`, and `commands/uninstall-achievements.md` to
+`commands/achievements-tutorial.md`, `commands/achievements-version.md`,
+`commands/achievements-update.md`, `commands/achievements-enable-update.md`,
+`commands/achievements-disable-update.md`, and `commands/uninstall-achievements.md` to
 `~/.claude/commands/`. Also copies `uninstall.sh` itself into
 `$ACHIEVEMENTS_DIR/uninstall.sh` so the slash command can find it without knowing
 the repo path.
 
-**Phase 3.5 — Auto-allowed commands:** adds permission patterns for `cheevos drain`
-and `cheevos show` to the allow list. These commands are used repeatedly during the
-`/achievements-tutorial` interactive tutorial. The patterns use wildcards (`*/.claude/achievements/cheevos`)
+**Phase 3.5 — Auto-allowed commands:** adds permission patterns for `cheevos drain`,
+`cheevos show`, `cheevos check-updates`, and the `rm`/`touch` operations for the
+`.no-auto-update` flag file. The patterns use wildcards (`*/.claude/achievements/cheevos`)
 to match any path expansion (tilde, $HOME, or full path) and trailing `*` to match
 flags, pipes, and redirects. This prevents repetitive permission prompts during the
-tutorial flow and improves user experience.
+tutorial and update management flows.
 
-**Phase 6.5 — Leaderboard configuration:**
+**Phase 6.5 — Auto-update preference:**
+- `--no-auto-update` flag parsed in argument parsing block
+- If `--no-auto-update` provided → `touch "$ACHIEVEMENTS_DIR/.no-auto-update"` to disable auto-updates
+- If flag is already present on disk → preserve it (upgrade path — user preference retained)
+- If neither → log that auto-updates are enabled
+- The flag file is checked at runtime by `session-start.sh` before calling `cheevos check-updates`
+
+**Phase 6.7 — Leaderboard configuration:**
 - `--leaderboard-secret SECRET` arg parsed before Phase 0
 - If arg provided → preserves existing `USER_ID` from conf (upgrade) or generates new UUID (fresh install) → writes enabled `leaderboard.conf` with `LEADERBOARD_SECRET=<blob>` → `chmod 600`
 - If no arg and conf exists → preserves (upgrade path)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ usage milestones, awards points, and surfaces progress through a live status bar
 
 ## Contents
 
-[Requirements](#requirements) · [Installation](#installation) · [Uninstallation](#uninstallation) · [Getting Started](#getting-started) · [Achievement List](#achievement-list) · [Notifications](#notifications) · [Auto-Updates](#auto-updates) · [Leaderboard](#leaderboard) · [Contributing](#contributing)
+[Requirements](#requirements) · [Installation](#installation) · [Uninstallation](#uninstallation) · [Slash Commands](#slash-commands) · [Getting Started](#getting-started) · [Achievement List](#achievement-list) · [Notifications](#notifications) · [Auto-Updates](#auto-updates) · [Leaderboard](#leaderboard) · [Contributing](#contributing)
 
 ---
 
@@ -53,6 +53,12 @@ The installer is **idempotent** — safe to re-run to upgrade. Your score and pr
 ./install.sh --leaderboard-secret <secret>
 ```
 
+**Optional:** Disable automatic daily update checks (see [Auto-Updates](#auto-updates)):
+
+```bash
+./install.sh --no-auto-update
+```
+
 **Verify the install:**
 
 ```bash
@@ -72,6 +78,22 @@ claude
 # Then run inside the session:
 /uninstall-achievements
 ```
+
+---
+
+## Slash Commands
+
+All slash commands run inside a Claude session (`claude`).
+
+| Command | Description |
+|---|---|
+| `/achievements` | Open the achievement browser web UI (filter, search, track progress) |
+| `/achievements-tutorial` | Interactive guided tour — 17 core achievements, 140 pts |
+| `/achievements-version` | Check the currently installed version |
+| `/achievements-update` | Force an immediate update check |
+| `/achievements-enable-update` | Re-enable automatic daily update checks |
+| `/achievements-disable-update` | Disable automatic daily update checks |
+| `/uninstall-achievements` | Interactive uninstall (removes hooks, optionally deletes state) |
 
 ---
 
@@ -141,32 +163,25 @@ The system automatically updates once per day on session start. Your progress is
 - **Binary + hooks:** The `cheevos` binary and all hook scripts are updated to the latest release
 - **Custom compilations:** Binary auto-updates are disabled if you built from source
 
-Check your installed version at any time inside a Claude session:
+Manage updates from inside a Claude session:
 
-```
-/achievements-version
-```
+| Command | Description |
+|---|---|
+| `/achievements-version` | Check the currently installed version |
+| `/achievements-update` | Force an immediate update check |
+| `/achievements-disable-update` | Disable automatic daily update checks |
+| `/achievements-enable-update` | Re-enable automatic daily update checks |
 
-Or from the terminal:
+### Disabling Auto-Updates
 
-```bash
-~/.claude/achievements/cheevos version
-```
-
-Force an immediate update check:
-
-```bash
-~/.claude/achievements/cheevos check-updates --force
-```
-
-**Opt out of binary auto-updates:**
+To disable at install time, pass `--no-auto-update` to the installer. When auto-updates are disabled the system will never contact GitHub on session start. Use
+`/achievements-update` to update manually at any time.
 
 ```bash
-touch ~/.claude/achievements/.no-auto-update
+./install.sh --no-auto-update
 ```
 
-See [docs/auto-update.md](docs/auto-update.md) for full details including security, rollback,
-and disabling updates.
+See [docs/auto-update.md](docs/auto-update.md) for full details including security and rollback.
 
 ---
 

--- a/commands/achievements-disable-update.md
+++ b/commands/achievements-disable-update.md
@@ -1,0 +1,13 @@
+Disable automatic daily update checks for the Claude Code Achievement System.
+This creates a `.no-auto-update` flag file that prevents the system from fetching
+updates from GitHub on session start.
+
+Use the Bash tool to run:
+
+```bash
+touch ~/.claude/achievements/.no-auto-update
+```
+
+Then tell the user: "Auto-updates are now disabled. The system will no longer check for
+updates on session start. You can still update manually at any time using /achievements-update,
+or re-enable auto-updates using /achievements-enable-update."

--- a/commands/achievements-enable-update.md
+++ b/commands/achievements-enable-update.md
@@ -1,0 +1,14 @@
+Re-enable automatic daily update checks for the Claude Code Achievement System.
+This removes the `.no-auto-update` flag file that was previously set to disable updates.
+
+Use the Bash tool to run:
+
+```bash
+rm -f ~/.claude/achievements/.no-auto-update
+```
+
+Then tell the user: "Auto-updates are now enabled. The system will check for new
+achievement definitions and binary updates once per day on session start."
+
+If the command succeeds silently (no output), that is the expected behavior — `rm -f`
+produces no output when the file does not exist or is successfully removed.

--- a/commands/achievements-update.md
+++ b/commands/achievements-update.md
@@ -1,0 +1,12 @@
+Force an immediate update check for the Claude Code Achievement System, downloading the
+latest achievement definitions, binary, and hook scripts from GitHub.
+
+Use the Bash tool to run:
+
+```bash
+~/.claude/achievements/cheevos check-updates --force
+```
+
+Display the output to the user verbatim. If the command reports that everything is already
+up to date, tell the user they are running the latest version. If it reports that an update
+was applied, tell the user to restart Claude Code for the changes to take effect.

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -138,6 +138,9 @@ export _CHEEVOS_TS
 "$CHEEVOS" update
 
 # Auto-update check (once per day, runs in background — rate-limited inside the binary)
-"$CHEEVOS" check-updates &
+# Skipped if the user has opted out by placing a .no-auto-update flag file.
+if [[ ! -f "$ACHIEVEMENTS_DIR/.no-auto-update" ]]; then
+    "$CHEEVOS" check-updates &
+fi
 
 exit 0

--- a/install.sh
+++ b/install.sh
@@ -12,17 +12,20 @@
 #   bash install.sh                           # basic install (leaderboard disabled)
 #   bash install.sh -cp                       # dev install: cp instead of mv (keeps repo files)
 #   bash install.sh --leaderboard-secret S    # install with leaderboard enabled
+#   bash install.sh --no-auto-update          # disable automatic daily update checks
 
 set -euo pipefail
 
 # ─── Argument parsing ─────────────────────────────────────────────────────────
 ARG_SECRET=""
 DEV_INSTALL=false
+ARG_NO_AUTO_UPDATE=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --leaderboard-secret) ARG_SECRET="${2:-}"; shift 2 ;;
         -cp|--copy) DEV_INSTALL=true; shift ;;
-        *) echo "Usage: bash install.sh [-cp|--copy] [--leaderboard-secret SECRET]"; exit 1 ;;
+        --no-auto-update) ARG_NO_AUTO_UPDATE=true; shift ;;
+        *) echo "Usage: bash install.sh [-cp|--copy] [--leaderboard-secret SECRET] [--no-auto-update]"; exit 1 ;;
     esac
 done
 
@@ -188,6 +191,9 @@ $FILE_CMD "$REPO_DIR/commands/achievements.md" "$COMMANDS_DIR/achievements.md"
 $FILE_CMD "$REPO_DIR/commands/achievements-tutorial.md" "$COMMANDS_DIR/achievements-tutorial.md"
 $FILE_CMD "$REPO_DIR/commands/uninstall-achievements.md" "$COMMANDS_DIR/uninstall-achievements.md"
 $FILE_CMD "$REPO_DIR/commands/achievements-version.md" "$COMMANDS_DIR/achievements-version.md"
+$FILE_CMD "$REPO_DIR/commands/achievements-update.md" "$COMMANDS_DIR/achievements-update.md"
+$FILE_CMD "$REPO_DIR/commands/achievements-enable-update.md" "$COMMANDS_DIR/achievements-enable-update.md"
+$FILE_CMD "$REPO_DIR/commands/achievements-disable-update.md" "$COMMANDS_DIR/achievements-disable-update.md"
 echo "✓ Slash commands installed to $COMMANDS_DIR"
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -267,13 +273,20 @@ fi
 # ─────────────────────────────────────────────────────────────────────────────
 
 # Add permission patterns for cheevos commands used during /achievements-tutorial tutorial
-# Patterns cover both ~ and $HOME expansions, with and without pipes/redirects
+# and the update-management slash commands. Patterns cover both ~ and $HOME expansions,
+# with and without pipes/redirects.
 CHEEVOS_DRAIN="Bash(*/.claude/achievements/cheevos drain*)"
 CHEEVOS_SHOW="Bash(*/.claude/achievements/cheevos show*)"
+CHEEVOS_CHECK_UPDATES="Bash(*/.claude/achievements/cheevos check-updates*)"
+CHEEVOS_NO_AUTO_UPDATE_RM="Bash(rm -f */.claude/achievements/.no-auto-update*)"
+CHEEVOS_NO_AUTO_UPDATE_TOUCH="Bash(touch */.claude/achievements/.no-auto-update*)"
 
 TEMP=$(mktemp "$SETTINGS.XXXXXX")
 jq --arg drain "$CHEEVOS_DRAIN" \
-   --arg show "$CHEEVOS_SHOW" '
+   --arg show "$CHEEVOS_SHOW" \
+   --arg check_updates "$CHEEVOS_CHECK_UPDATES" \
+   --arg rm_flag "$CHEEVOS_NO_AUTO_UPDATE_RM" \
+   --arg touch_flag "$CHEEVOS_NO_AUTO_UPDATE_TOUCH" '
     .permissions //= {} |
     .permissions.allow //= [] |
     if (.permissions.allow | any(. == $drain)) then .
@@ -281,6 +294,15 @@ jq --arg drain "$CHEEVOS_DRAIN" \
     end |
     if (.permissions.allow | any(. == $show)) then .
     else .permissions.allow += [$show]
+    end |
+    if (.permissions.allow | any(. == $check_updates)) then .
+    else .permissions.allow += [$check_updates]
+    end |
+    if (.permissions.allow | any(. == $rm_flag)) then .
+    else .permissions.allow += [$rm_flag]
+    end |
+    if (.permissions.allow | any(. == $touch_flag)) then .
+    else .permissions.allow += [$touch_flag]
     end
 ' "$SETTINGS" > "$TEMP"
 
@@ -325,7 +347,21 @@ fi
 printf '%s' "$VERSION" > "$ACHIEVEMENTS_DIR/.version"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Phase 6.5: Leaderboard configuration
+# Phase 6.5: Auto-update preference
+# ─────────────────────────────────────────────────────────────────────────────
+
+NO_AUTO_UPDATE_FLAG="$ACHIEVEMENTS_DIR/.no-auto-update"
+if [[ "$ARG_NO_AUTO_UPDATE" == "true" ]]; then
+    touch "$NO_AUTO_UPDATE_FLAG"
+    echo "✓ Auto-updates disabled (.no-auto-update flag set)"
+elif [[ ! -f "$NO_AUTO_UPDATE_FLAG" ]]; then
+    echo "✓ Auto-updates enabled (use --no-auto-update to disable, or /achievements-disable-update)"
+else
+    echo "✓ Auto-update preference preserved (already disabled — use /achievements-enable-update to re-enable)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 6.7: Leaderboard configuration
 # Three cases:
 #   A) --leaderboard-secret provided  → preserve existing USER_ID (upgrade) or generate new UUID, write enabled conf
 #   B) No args, conf already exists   → preserve (upgrade)
@@ -396,6 +432,11 @@ echo ""
 echo "View your achievements (inside a Claude session):"
 echo "  /achievements                              (opens web UI in browser)"
 echo "  /achievements-tutorial                               (interactive guided tour)"
+echo ""
+echo "Manage updates (inside a Claude session):"
+echo "  /achievements-update                             (force update now)"
+echo "  /achievements-enable-update                (re-enable auto-updates)"
+echo "  /achievements-disable-update               (disable auto-updates)"
 echo ""
 echo "View your achievements (from terminal):"
 echo "  $ACHIEVEMENTS_DIR/cheevos serve           (opens web UI in browser)"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -68,7 +68,7 @@ echo "✓ Removed achievement hooks from settings.json"
 TEMP=$(mktemp "$SETTINGS.XXXXXX")
 jq '
     if .permissions.allow then
-        .permissions.allow |= map(select(test("achievements/cheevos") | not))
+        .permissions.allow |= map(select(test("\\.claude/achievements") | not))
     else . end
 ' "$SETTINGS" > "$TEMP" && mv "$TEMP" "$SETTINGS"
 echo "✓ Removed cheevos from permissions allow list"
@@ -77,23 +77,21 @@ echo "✓ Removed cheevos from permissions allow list"
 # Step 2.6: Remove slash commands
 # ─────────────────────────────────────────────────────────────────────────────
 
-COMMAND_FILE="$HOME/.claude/commands/achievements.md"
-if [[ -f "$COMMAND_FILE" ]]; then
-    rm -f "$COMMAND_FILE"
-    echo "✓ Removed /achievements slash command"
-fi
-
-UNINSTALL_COMMAND_FILE="$HOME/.claude/commands/uninstall-achievements.md"
-if [[ -f "$UNINSTALL_COMMAND_FILE" ]]; then
-    rm -f "$UNINSTALL_COMMAND_FILE"
-    echo "✓ Removed /uninstall-achievements slash command"
-fi
-
-TUTORIAL_COMMAND_FILE="$HOME/.claude/commands/achievements-tutorial.md"
-if [[ -f "$TUTORIAL_COMMAND_FILE" ]]; then
-    rm -f "$TUTORIAL_COMMAND_FILE"
-    echo "✓ Removed /achievements-tutorial slash command"
-fi
+for CMD_FILE in \
+    achievements.md \
+    achievements-tutorial.md \
+    achievements-version.md \
+    achievements-update.md \
+    achievements-enable-update.md \
+    achievements-disable-update.md \
+    uninstall-achievements.md
+do
+    FULL_PATH="$HOME/.claude/commands/$CMD_FILE"
+    if [[ -f "$FULL_PATH" ]]; then
+        rm -f "$FULL_PATH"
+        echo "✓ Removed /${CMD_FILE%.md} slash command"
+    fi
+done
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Step 3: Remove from leaderboard (if enabled)


### PR DESCRIPTION
For users who want to validate updates before allowing them to install, auto-updates can now be disabled to prevent the system from fetching new binaries or definitions from GitHub without explicit user approval.

- Add --no-auto-update flag to install.sh; creates .no-auto-update flag file
- Guard cheevos check-updates in session-start.sh with flag file check
- Add /achievements-update slash command to trigger updates manually
- Add /achievements-enable-update and /achievements-disable-update slash commands
- Update uninstall.sh to clean up new permission entries and all slash commands
- Document everything in README.md with a new Slash Commands reference table