### PR TITLE
Add achievements for Learning and Explanatory output styles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -506,6 +506,8 @@ decrypt correctly when the matching binary (built with the same `CHEEVOS_HMAC_KE
 | `lucky_sessions` | stop.sh: output_tokens == 777 |
 | `easter_egg_unlocks` | award subcommand (manual) |
 | `self_reads` | Read: path contains /.claude/achievements/ |
+| `learning_mode_sessions` | session-start.sh: outputStyle contains "learning" |
+| `explanatory_mode_sessions` | session-start.sh: outputStyle contains "explanatory" |
 
 ## state.json Schema (encrypted — fields listed for reference)
 

--- a/data/definitions.json
+++ b/data/definitions.json
@@ -1013,6 +1013,30 @@
             }
         },
         {
+            "id": "student_driver",
+            "name": "Student Driver",
+            "description": "Start a session with Claude's Learning output style enabled",
+            "points": 10,
+            "category": "misc",
+            "skill_level": "beginner",
+            "condition": {
+                "counter": "learning_mode_sessions",
+                "threshold": 1
+            }
+        },
+        {
+            "id": "explain_like_im_5",
+            "name": "Explain Like I'm 5",
+            "description": "Start a session with Claude's Explanatory output style enabled",
+            "points": 10,
+            "category": "misc",
+            "skill_level": "beginner",
+            "condition": {
+                "counter": "explanatory_mode_sessions",
+                "threshold": 1
+            }
+        },
+        {
             "id": "write_that_down",
             "name": "Write That Down, Write That Down!",
             "description": "Add information to a CLAUDE.md file when context is over 90% full",

--- a/docs/achievement_list.md
+++ b/docs/achievement_list.md
@@ -129,6 +129,8 @@ The **Tutorial** column marks achievements in the interactive guided tour (`/ach
 | F Is for Friends Who Do Stuff Together! | 0.1% chance to unlock with each prompt | 25 | misc | **Secret** |  |
 | Deja Vu | Send the same message to Claude twice in a row | 20 | misc | **Secret** |  |
 | Style Points | Set a custom status line command in Claude Code | 10 | misc | Beginner |  |
+| Student Driver | Start a session with Claude's Learning output style enabled | 10 | misc | Beginner |  |
+| Explain Like I'm 5 | Start a session with Claude's Explanatory output style enabled | 10 | misc | Beginner |  |
 | The Inner Machinations of My Mind Are an Enigma | Ask Claude to explain or summarize a codebase | 10 | misc | Beginner | ✓ |
 | Snake Charmer | Have Claude read a Python file | 5 | misc | Beginner |  |
 | Segfault Risk | Have Claude read a C or C++ file | 5 | misc | Beginner |  |

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -126,6 +126,25 @@ if [[ "$HAS_CUSTOM_STATUSLINE" == "true" ]]; then
     UPDATES=$(printf '%s' "$UPDATES" | jq '. + {"custom_statusline_set": 1}')
 fi
 
+# Learning/Explanatory output style detection
+# Check project-local (highest precedence), user-local, then user-global settings
+OUTPUT_STYLE=""
+for SETTINGS_CANDIDATE in ".claude/settings.local.json" "$HOME/.claude/settings.local.json" "$HOME/.claude/settings.json"; do
+    if [[ -f "$SETTINGS_CANDIDATE" ]]; then
+        CANDIDATE_STYLE=$(jq -r '.outputStyle // ""' "$SETTINGS_CANDIDATE")
+        if [[ -n "$CANDIDATE_STYLE" ]]; then
+            OUTPUT_STYLE="$CANDIDATE_STYLE"
+            break
+        fi
+    fi
+done
+if printf '%s' "$OUTPUT_STYLE" | grep -qi "learning"; then
+    UPDATES=$(printf '%s' "$UPDATES" | jq '. + {"learning_mode_sessions": 1}')
+fi
+if printf '%s' "$OUTPUT_STYLE" | grep -qi "explanatory"; then
+    UPDATES=$(printf '%s' "$UPDATES" | jq '. + {"explanatory_mode_sessions": 1}')
+fi
+
 export _COUNTER_UPDATES="$UPDATES"
 export _STATE_FILE="$STATE_FILE"
 export _NOTIFICATIONS_FILE="$NOTIFICATIONS_FILE"


### PR DESCRIPTION
## Summary

Closes #60 — adds two new beginner achievements for Claude Code's educational output styles ([docs](https://code.claude.com/docs/en/output-styles)):

- **Student Driver** (10 pts) — start a session with Learning mode enabled, which adds `TODO(human)` markers for the user to implement code themselves
- **Explain Like I'm 5** (10 pts) — start a session with Explanatory mode enabled, which provides educational "Insights" alongside normal coding assistance

### How detection works

The session-start hook reads the `outputStyle` field from settings files at startup, checking in precedence order:
1. `.claude/settings.local.json` (project-local)
2. `~/.claude/settings.local.json` (user-local)
3. `~/.claude/settings.json` (user-global)

Case-insensitive matching via `grep -qi` (Bash 3.2 compatible).

### Files changed

| File | Change |
|---|---|
| `hooks/session-start.sh` | Output style detection logic (new counters: `learning_mode_sessions`, `explanatory_mode_sessions`) |
| `data/definitions.json` | Two new achievement entries in misc category |
| `docs/achievement_list.md` | Two new rows in achievement table |
| `.claude/CLAUDE.md` | Two new entries in counter reference table |

## Test plan

- [x] `bash -n hooks/session-start.sh` — syntax check passes
- [x] `jq . data/definitions.json > /dev/null` — valid JSON
- [ ] Set `"outputStyle": "Learning"` in `~/.claude/settings.local.json` → start session → "Student Driver" unlocks
- [ ] Set `"outputStyle": "Explanatory"` → start session → "Explain Like I'm 5" unlocks
- [ ] No `outputStyle` set → neither achievement fires (no false positive)